### PR TITLE
Remove synchronized methods from SDK method code path

### DIFF
--- a/src/us/kbase/narrativejobservice/db/ExecEngineMongoDb.java
+++ b/src/us/kbase/narrativejobservice/db/ExecEngineMongoDb.java
@@ -25,247 +25,247 @@ import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
 
 public class ExecEngineMongoDb {
-    private DB mongo;
-    private Jongo jongo;
-    private MongoCollection taskQueue;
-    private MongoCollection execApps;
-    private MongoCollection execTasks;
-    private MongoCollection execLogs;
-    private MongoCollection srvProps;
-    private volatile boolean wasDbVersionChecked = false;
+	private DB mongo;
+	private Jongo jongo;
+	private MongoCollection taskQueue;
+	private MongoCollection execApps;
+	private MongoCollection execTasks;
+	private MongoCollection execLogs;
+	private MongoCollection srvProps;
+	private volatile boolean wasDbVersionChecked = false;
 
-    private static final Map<String, MongoClient> HOSTS_TO_CLIENT = 
-            new HashMap<String, MongoClient>();
-    
-    public static final String COL_TASK_QUEUE = "task_queue";
-    public static final String PK_TASK_QUEUE = "jobid";
-    public static final String COL_EXEC_APPS = "exec_apps";
-    public static final String PK_EXEC_APPS = "app_job_id";
-    public static final String FLD_EXEC_APPS_APP_JOB_STATE = "app_job_state";
-    public static final String COL_EXEC_TASKS = "exec_tasks";
-    public static final String PK_EXEC_TASKS = "ujs_job_id";
-    public static final String COL_EXEC_LOGS = "exec_logs";
-    public static final String PK_EXEC_LOGS = "ujs_job_id";
-    public static final String COL_SRV_PROPS = "srv_props";
-    public static final String PK_SRV_PROPS = "prop_id";
-    public static final String SRV_PROP_DB_VERSION = "db_version";
-    
-    public static final String DB_VERSION = "1.0";
+	private static final Map<String, MongoClient> HOSTS_TO_CLIENT = 
+			new HashMap<String, MongoClient>();
 
-    public ExecEngineMongoDb(String hosts, String db, String user, String pwd,
-            Integer mongoReconnectRetry) throws Exception {
-        mongo = getDB(hosts, db, user, pwd, 
-                mongoReconnectRetry == null ? 0 : mongoReconnectRetry, 10);
-        jongo = new Jongo(mongo);
-        taskQueue = jongo.getCollection(COL_TASK_QUEUE);
-        execApps = jongo.getCollection(COL_EXEC_APPS);
-        execTasks = jongo.getCollection(COL_EXEC_TASKS);
-        execLogs = jongo.getCollection(COL_EXEC_LOGS);
-        srvProps = jongo.getCollection(COL_SRV_PROPS);
-        // Indexing
-        taskQueue.ensureIndex(String.format("{%s:1}", PK_TASK_QUEUE), "{unique:true}");
-        execTasks.ensureIndex(String.format("{%s:1}", PK_EXEC_TASKS), "{unique:true}");
-        execApps.ensureIndex(String.format("{%s:1}", PK_EXEC_APPS), "{unique:true}");
-        execApps.ensureIndex(String.format("{%s:1}", FLD_EXEC_APPS_APP_JOB_STATE), "{unique:false}");
-        execLogs.ensureIndex(String.format("{%s:1}", PK_EXEC_LOGS), "{unique:true}");
-        srvProps.ensureIndex(String.format("{%s:1}", PK_SRV_PROPS), "{unique:true}");
-    }
-    
-    public List<QueuedTask> getQueuedTasks() throws Exception {
-        return Lists.newArrayList(taskQueue.find("{}").as(QueuedTask.class));
-    }
+	public static final String COL_TASK_QUEUE = "task_queue";
+	public static final String PK_TASK_QUEUE = "jobid";
+	public static final String COL_EXEC_APPS = "exec_apps";
+	public static final String PK_EXEC_APPS = "app_job_id";
+	public static final String FLD_EXEC_APPS_APP_JOB_STATE = "app_job_state";
+	public static final String COL_EXEC_TASKS = "exec_tasks";
+	public static final String PK_EXEC_TASKS = "ujs_job_id";
+	public static final String COL_EXEC_LOGS = "exec_logs";
+	public static final String PK_EXEC_LOGS = "ujs_job_id";
+	public static final String COL_SRV_PROPS = "srv_props";
+	public static final String PK_SRV_PROPS = "prop_id";
+	public static final String SRV_PROP_DB_VERSION = "db_version";
 
-    public void insertQueuedTask(QueuedTask task) throws Exception {
-        checkForDbVersion();
-        taskQueue.insert(task);
-    }
-    
-    public void deleteQueuedTask(String jobId) throws Exception {
-        checkForDbVersion();
-        taskQueue.remove(String.format("{%s:#}", PK_TASK_QUEUE), jobId);
-    }
+	public static final String DB_VERSION = "1.0";
 
-    public void insertExecApp(ExecApp execApp) throws Exception {
-        checkForDbVersion();
-        execApps.insert(execApp);
-    }
-    
-    public ExecApp getExecApp(String appJobId) throws Exception {
-        List<ExecApp> ret = Lists.newArrayList(execApps.find(
-                String.format("{%s:#}", PK_EXEC_APPS), appJobId).as(ExecApp.class));
-        return ret.size() > 0 ? ret.get(0) : null;
-    }
-    
-    public void updateExecAppData(String appJobId, String appJobState, 
-            String appStateData) throws Exception {
-        checkForDbVersion();
-        ExecApp execApp = getExecApp(appJobId);
-        if (execApp == null)
-            throw new IllegalStateException("App id=" + appJobId + " wasn't found in database");
-        execApp.setAppJobState(appJobState);
-        execApp.setAppStateData(appStateData);
-        execApp.setModificationTime(System.currentTimeMillis());
-        execApps.update(String.format("{%s:#}", PK_EXEC_APPS), appJobId).with("#", execApp);
-    }
-    
-    public List<ExecApp> getExecAppsWithState(String appJobState) throws Exception {
-        return Lists.newArrayList(execApps.find(
-                String.format("{%s:#}", FLD_EXEC_APPS_APP_JOB_STATE), appJobState).as(ExecApp.class));
-    }
-    
-    public ExecLog getExecLog(String ujsJobId) throws Exception {
-        List<ExecLog> ret = Lists.newArrayList(execLogs.find(
-                String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId)
-                .projection(String.format("{%s:1,%s:1,%s:1}", PK_EXEC_LOGS,
-                        "original_line_count", "stored_line_count")).as(ExecLog.class));
-        return ret.size() > 0 ? ret.get(0) : null;
-    }
+	public ExecEngineMongoDb(String hosts, String db, String user, String pwd,
+			Integer mongoReconnectRetry) throws Exception {
+		mongo = getDB(hosts, db, user, pwd, 
+				mongoReconnectRetry == null ? 0 : mongoReconnectRetry, 10);
+		jongo = new Jongo(mongo);
+		taskQueue = jongo.getCollection(COL_TASK_QUEUE);
+		execApps = jongo.getCollection(COL_EXEC_APPS);
+		execTasks = jongo.getCollection(COL_EXEC_TASKS);
+		execLogs = jongo.getCollection(COL_EXEC_LOGS);
+		srvProps = jongo.getCollection(COL_SRV_PROPS);
+		// Indexing
+		taskQueue.ensureIndex(String.format("{%s:1}", PK_TASK_QUEUE), "{unique:true}");
+		execTasks.ensureIndex(String.format("{%s:1}", PK_EXEC_TASKS), "{unique:true}");
+		execApps.ensureIndex(String.format("{%s:1}", PK_EXEC_APPS), "{unique:true}");
+		execApps.ensureIndex(String.format("{%s:1}", FLD_EXEC_APPS_APP_JOB_STATE), "{unique:false}");
+		execLogs.ensureIndex(String.format("{%s:1}", PK_EXEC_LOGS), "{unique:true}");
+		srvProps.ensureIndex(String.format("{%s:1}", PK_SRV_PROPS), "{unique:true}");
+	}
 
-    public void insertExecLog(ExecLog execLog) throws Exception {
-        checkForDbVersion();
-        execLogs.insert(execLog);
-    }
+	public List<QueuedTask> getQueuedTasks() throws Exception {
+		return Lists.newArrayList(taskQueue.find("{}").as(QueuedTask.class));
+	}
 
-    public void insertExecLogs(List<ExecLog> execLogList) throws Exception {
-        checkForDbVersion();
-        Object[] execLogArray = execLogList.toArray(new Object[execLogList.size()]);
-        execLogs.insert(execLogArray);
-    }
+	public void insertQueuedTask(QueuedTask task) throws Exception {
+		checkForDbVersion();
+		taskQueue.insert(task);
+	}
 
-    public void updateExecLogLines(String ujsJobId, int newLineCount, 
-            List<ExecLogLine> newLines) throws Exception {
-        checkForDbVersion();
-        execLogs.update(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).with(
-                String.format("{$set:{%s:#,%s:#},$push:{%s:{$each:#}}}", 
-                        "original_line_count", "stored_line_count", "lines"), 
-                        newLineCount, newLineCount, newLines);
-    }
+	public void deleteQueuedTask(String jobId) throws Exception {
+		checkForDbVersion();
+		taskQueue.remove(String.format("{%s:#}", PK_TASK_QUEUE), jobId);
+	}
 
-    public void updateExecLogOriginalLineCount(String ujsJobId, int newLineCount) throws Exception {
-        checkForDbVersion();
-        execLogs.update(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).with(
-                String.format("{$set:{%s:#}}", "original_line_count"), newLineCount);
-    }
-    
-    public List<ExecLogLine> getExecLogLines(String ujsJobId, int from, int count) throws Exception {
-        return execLogs.findOne(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).projection(
-                String.format("{%s:{$slice:[#,#]}}", "lines"), from, count).as(ExecLog.class).getLines();
-    }
+	public void insertExecApp(ExecApp execApp) throws Exception {
+		checkForDbVersion();
+		execApps.insert(execApp);
+	}
 
-    public void insertExecTask(ExecTask execTask) throws Exception {
-        checkForDbVersion();
-        execTasks.insert(execTask);
-    }
-    
-    public ExecTask getExecTask(String ujsJobId) throws Exception {
-        List<ExecTask> ret = Lists.newArrayList(execTasks.find(
-                String.format("{%s:#}", PK_EXEC_TASKS), ujsJobId).as(ExecTask.class));
-        return ret.size() > 0 ? ret.get(0) : null;
-    }
+	public ExecApp getExecApp(String appJobId) throws Exception {
+		List<ExecApp> ret = Lists.newArrayList(execApps.find(
+				String.format("{%s:#}", PK_EXEC_APPS), appJobId).as(ExecApp.class));
+		return ret.size() > 0 ? ret.get(0) : null;
+	}
 
-    public void updateExecTaskTime(String ujsJobId, boolean finishTime, long time) throws Exception {
-        checkForDbVersion();
-        execTasks.update(String.format("{%s:#}", PK_EXEC_TASKS), ujsJobId).with(
-                String.format("{$set:{%s:#}}", finishTime ? "finish_time" : "exec_start_time"), time);
-    }
+	public void updateExecAppData(String appJobId, String appJobState, 
+			String appStateData) throws Exception {
+		checkForDbVersion();
+		ExecApp execApp = getExecApp(appJobId);
+		if (execApp == null)
+			throw new IllegalStateException("App id=" + appJobId + " wasn't found in database");
+		execApp.setAppJobState(appJobState);
+		execApp.setAppStateData(appStateData);
+		execApp.setModificationTime(System.currentTimeMillis());
+		execApps.update(String.format("{%s:#}", PK_EXEC_APPS), appJobId).with("#", execApp);
+	}
 
-    public String getServiceProperty(String propId) throws Exception {
-        String valueField = "value";
-        @SuppressWarnings("rawtypes")
-        List<Map> ret = Lists.newArrayList(srvProps.find(String.format("{%s:#}", PK_SRV_PROPS), propId)
-                .projection(String.format("{%s:1}", valueField)).as(Map.class));
-        if (ret.size() == 0)
-            return null;
-        return (String)ret.get(0).get(valueField);
-    }
-    
-    public void setServiceProperty(String propId, String value) throws Exception {
-        String valueField = "value";
-        srvProps.update(String.format("{%s:#}", PK_SRV_PROPS), propId).upsert().with(
-                String.format("{$set:{%s:#}}", valueField), value);
-    }
-    
-    private void checkForDbVersion() throws Exception {
-        if (!wasDbVersionChecked) {
-        //TODO SYNC needs removal
-            synchronized(this) {
-                String ver = getServiceProperty(SRV_PROP_DB_VERSION);
-                if (ver == null)
-                    setServiceProperty(SRV_PROP_DB_VERSION, DB_VERSION);
-                wasDbVersionChecked = true;
-            }
-        }
-    }
-    
-    private synchronized static MongoClient getMongoClient(final String hosts)
-            throws UnknownHostException, InvalidHostException {
-        //Only make one instance of MongoClient per JVM per mongo docs
-        final MongoClient client;
-        if (!HOSTS_TO_CLIENT.containsKey(hosts)) {
-            // Don't print to stderr
-            java.util.logging.Logger.getLogger("com.mongodb")
-                    .setLevel(Level.OFF);
-            @SuppressWarnings("deprecation")
-            final MongoClientOptions opts = MongoClientOptions.builder()
-                    .autoConnectRetry(true).build();
-            try {
-                List<ServerAddress> addr = new ArrayList<ServerAddress>();
-                for (String s: hosts.split(","))
-                    addr.add(new ServerAddress(s));
-                client = new MongoClient(addr, opts);
-            } catch (NumberFormatException nfe) {
-                //throw a better exception if 10gen ever fixes this
-                throw new InvalidHostException(hosts
-                        + " is not a valid mongodb host");
-            }
-            HOSTS_TO_CLIENT.put(hosts, client);
-        } else {
-            client = HOSTS_TO_CLIENT.get(hosts);
-        }
-        return client;
-    }
+	public List<ExecApp> getExecAppsWithState(String appJobState) throws Exception {
+		return Lists.newArrayList(execApps.find(
+				String.format("{%s:#}", FLD_EXEC_APPS_APP_JOB_STATE), appJobState).as(ExecApp.class));
+	}
 
-    @SuppressWarnings("deprecation")
-    private static DB getDB(final String hosts, final String database,
-            final String user, final String pwd,
-            final int retryCount, final int logIntervalCount)
-            throws UnknownHostException, InvalidHostException, IOException,
-            MongoAuthException, InterruptedException {
-        if (database == null || database.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "database may not be null or the empty string");
-        }
-        final DB db = getMongoClient(hosts).getDB(database);
-        if (user != null && pwd != null) {
-            int retries = 0;
-            while (true) {
-                try {
-                    db.authenticate(user, pwd.toCharArray());
-                    break;
-                } catch (MongoException.Network men) {
-                    if (retries >= retryCount) {
-                        throw (IOException) men.getCause();
-                    }
-                    if (retries % logIntervalCount == 0) {
-                        getLogger().info(
-                                "Retrying MongoDB connection {}/{}, attempt {}/{}",
-                                hosts, database, retries, retryCount);
-                    }
-                    Thread.sleep(1000);
-                }
-                retries++;
-            }
-        }
-        try {
-            db.getCollectionNames();
-        } catch (MongoException me) {
-            throw new MongoAuthException("Not authorized for database "
-                    + database, me);
-        }
-        return db;
-    }
-    
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(GetMongoDB.class);
-    }
+	public ExecLog getExecLog(String ujsJobId) throws Exception {
+		List<ExecLog> ret = Lists.newArrayList(execLogs.find(
+				String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId)
+				.projection(String.format("{%s:1,%s:1,%s:1}", PK_EXEC_LOGS,
+						"original_line_count", "stored_line_count")).as(ExecLog.class));
+		return ret.size() > 0 ? ret.get(0) : null;
+	}
+
+	public void insertExecLog(ExecLog execLog) throws Exception {
+		checkForDbVersion();
+		execLogs.insert(execLog);
+	}
+
+	public void insertExecLogs(List<ExecLog> execLogList) throws Exception {
+		checkForDbVersion();
+		Object[] execLogArray = execLogList.toArray(new Object[execLogList.size()]);
+		execLogs.insert(execLogArray);
+	}
+
+	public void updateExecLogLines(String ujsJobId, int newLineCount, 
+			List<ExecLogLine> newLines) throws Exception {
+		checkForDbVersion();
+		execLogs.update(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).with(
+				String.format("{$set:{%s:#,%s:#},$push:{%s:{$each:#}}}", 
+						"original_line_count", "stored_line_count", "lines"), 
+						newLineCount, newLineCount, newLines);
+	}
+
+	public void updateExecLogOriginalLineCount(String ujsJobId, int newLineCount) throws Exception {
+		checkForDbVersion();
+		execLogs.update(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).with(
+				String.format("{$set:{%s:#}}", "original_line_count"), newLineCount);
+	}
+
+	public List<ExecLogLine> getExecLogLines(String ujsJobId, int from, int count) throws Exception {
+		return execLogs.findOne(String.format("{%s:#}", PK_EXEC_LOGS), ujsJobId).projection(
+				String.format("{%s:{$slice:[#,#]}}", "lines"), from, count).as(ExecLog.class).getLines();
+	}
+
+	public void insertExecTask(ExecTask execTask) throws Exception {
+		checkForDbVersion();
+		execTasks.insert(execTask);
+	}
+
+	public ExecTask getExecTask(String ujsJobId) throws Exception {
+		List<ExecTask> ret = Lists.newArrayList(execTasks.find(
+				String.format("{%s:#}", PK_EXEC_TASKS), ujsJobId).as(ExecTask.class));
+		return ret.size() > 0 ? ret.get(0) : null;
+	}
+
+	public void updateExecTaskTime(String ujsJobId, boolean finishTime, long time) throws Exception {
+		checkForDbVersion();
+		execTasks.update(String.format("{%s:#}", PK_EXEC_TASKS), ujsJobId).with(
+				String.format("{$set:{%s:#}}", finishTime ? "finish_time" : "exec_start_time"), time);
+	}
+
+	public String getServiceProperty(String propId) throws Exception {
+		String valueField = "value";
+		@SuppressWarnings("rawtypes")
+		List<Map> ret = Lists.newArrayList(srvProps.find(String.format("{%s:#}", PK_SRV_PROPS), propId)
+				.projection(String.format("{%s:1}", valueField)).as(Map.class));
+		if (ret.size() == 0)
+			return null;
+		return (String)ret.get(0).get(valueField);
+	}
+
+	public void setServiceProperty(String propId, String value) throws Exception {
+		String valueField = "value";
+		srvProps.update(String.format("{%s:#}", PK_SRV_PROPS), propId).upsert().with(
+				String.format("{$set:{%s:#}}", valueField), value);
+	}
+
+	private void checkForDbVersion() throws Exception {
+		if (!wasDbVersionChecked) {
+			//TODO SYNC needs removal
+			synchronized(this) {
+				String ver = getServiceProperty(SRV_PROP_DB_VERSION);
+				if (ver == null)
+					setServiceProperty(SRV_PROP_DB_VERSION, DB_VERSION);
+				wasDbVersionChecked = true;
+			}
+		}
+	}
+
+	private synchronized static MongoClient getMongoClient(final String hosts)
+			throws UnknownHostException, InvalidHostException {
+		//Only make one instance of MongoClient per JVM per mongo docs
+		final MongoClient client;
+		if (!HOSTS_TO_CLIENT.containsKey(hosts)) {
+			// Don't print to stderr
+			java.util.logging.Logger.getLogger("com.mongodb")
+			.setLevel(Level.OFF);
+			@SuppressWarnings("deprecation")
+			final MongoClientOptions opts = MongoClientOptions.builder()
+			.autoConnectRetry(true).build();
+			try {
+				List<ServerAddress> addr = new ArrayList<ServerAddress>();
+				for (String s: hosts.split(","))
+					addr.add(new ServerAddress(s));
+				client = new MongoClient(addr, opts);
+			} catch (NumberFormatException nfe) {
+				//throw a better exception if 10gen ever fixes this
+				throw new InvalidHostException(hosts
+						+ " is not a valid mongodb host");
+			}
+			HOSTS_TO_CLIENT.put(hosts, client);
+		} else {
+			client = HOSTS_TO_CLIENT.get(hosts);
+		}
+		return client;
+	}
+
+	@SuppressWarnings("deprecation")
+	private static DB getDB(final String hosts, final String database,
+			final String user, final String pwd,
+			final int retryCount, final int logIntervalCount)
+					throws UnknownHostException, InvalidHostException, IOException,
+					MongoAuthException, InterruptedException {
+		if (database == null || database.isEmpty()) {
+			throw new IllegalArgumentException(
+					"database may not be null or the empty string");
+		}
+		final DB db = getMongoClient(hosts).getDB(database);
+		if (user != null && pwd != null) {
+			int retries = 0;
+			while (true) {
+				try {
+					db.authenticate(user, pwd.toCharArray());
+					break;
+				} catch (MongoException.Network men) {
+					if (retries >= retryCount) {
+						throw (IOException) men.getCause();
+					}
+					if (retries % logIntervalCount == 0) {
+						getLogger().info(
+								"Retrying MongoDB connection {}/{}, attempt {}/{}",
+								hosts, database, retries, retryCount);
+					}
+					Thread.sleep(1000);
+				}
+				retries++;
+			}
+		}
+		try {
+			db.getCollectionNames();
+		} catch (MongoException me) {
+			throw new MongoAuthException("Not authorized for database "
+					+ database, me);
+		}
+		return db;
+	}
+
+	private static Logger getLogger() {
+		return LoggerFactory.getLogger(GetMongoDB.class);
+	}
 }

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -77,11 +77,9 @@ public class SDKMethodRunner {
 
 	private static ExecEngineMongoDb db = null;
 
-	//TODO SYNC remove sync after checking DB
-	public static synchronized AppState loadAppState(String appJobId, Map<String, String> config)
+	public static AppState loadAppState(String appJobId, Map<String, String> config)
 			throws Exception {
-		ExecEngineMongoDb db = getDb(config);
-		ExecApp dbApp = db.getExecApp(appJobId);
+		ExecApp dbApp = getDb(config).getExecApp(appJobId);
 		return dbApp == null ? null : UObject.getMapper().readValue(
 				dbApp.getAppStateData(), AppState.class);
 	}


### PR DESCRIPTION
@scanon 

There are still synchronized methods / blocks in other parts of the code, but once the NJSW exclusively runs SDK methods it can be scaled horizontally (or at least there are no known reasons why it can't be).