### PR TITLE
If start UJS job fails, try to continue or throw useful error

### DIFF
--- a/src/us/kbase/common/utils/ProcessHelper.java
+++ b/src/us/kbase/common/utils/ProcessHelper.java
@@ -39,13 +39,10 @@ public class ProcessHelper {
 
     public static ProcessHelper exec(CommandHolder cmd, File workDir, File input, File output, File error, boolean waitFor) throws IOException {
         ProcessHelper ret;
-        try ( // apparently Eclipse doesn't understand try with resources yet
-            @SuppressWarnings("resource")
+        try (
             BufferedReader br = input == null ? null :
                 new BufferedReader(new FileReader(input));
-            @SuppressWarnings("resource")
             PrintWriter pw = output == null ? null : new PrintWriter(output);
-            @SuppressWarnings("resource")
             PrintWriter epw = error == null ? null : new PrintWriter(error)
         ) {
             ret = exec(cmd, workDir, br, pw, epw, waitFor);

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
@@ -106,6 +106,14 @@ public class SDKLocalMethodRunner {
         LineLogger log = null;
         Server callbackServer = null;
         try {
+            log = new LineLogger() {
+                @Override
+                public void logNextLine(String line, boolean isError) {
+                    addLogLine(jobSrvClient, jobId, logLines,
+                            new LogLine().withLine(line)
+                                .withIsError(isError ? 1L : 0L));
+                }
+            };
             Tuple2<RunJobParams, Map<String,String>> jobInput = jobSrvClient.getJobParams(jobId);
             Map<String, String> config = jobInput.getE2();
             final URL catalogURL = getURL(jobInput.getE2(),
@@ -120,18 +128,19 @@ public class SDKLocalMethodRunner {
                         "Execution engine job for " + job.getMethod(), 
                         new InitProgress().withPtype("none"), null);
             } catch (ServerException se) {
-                System.out.println("Error starting UJS job:\n" + se.getData());
                 if (se.getLocalizedMessage().contains(
                         "no unstarted job " + jobId)) {
                     final String jobstage =
                             ujsClient.getJobStatus(jobId).getE2();
                     if ("started".equals(jobstage)) {
-                        System.out.println(
-                                "Job already in started state, continuing");
+                        log.logNextLine(String.format(
+                                "UJS Job %s is already in started state, continuing",
+                                jobId), false);
                     } else {
                         throw new IllegalStateException(String.format(
-                                "Job %s couldn't be started and is in state %s",
-                                jobId, jobstage));
+                                "Job %s couldn't be started and is in state " +
+                                "%s. Server stacktrace:\n%s",
+                                jobId, jobstage, se.getData()), se);
                     }
                 } else {
                     throw se;
@@ -171,12 +180,7 @@ public class SDKLocalMethodRunner {
                 pw.println("kbase_endpoint = " + kbaseEndpoint);
             pw.close();
             ujsClient.updateJob(jobId, token.toString(), "running", null);
-            log = new LineLogger() {
-                @Override
-                public void logNextLine(String line, boolean isError) {
-                    addLogLine(jobSrvClient, jobId, logLines, new LogLine().withLine(line).withIsError(isError ? 1L : 0L));
-                }
-            };
+            
             log.logNextLine("Running on " + hostnameAndIP[0] + " (" + hostnameAndIP[1] + "), in " +
                     new File(".").getCanonicalPath(), false);
             String clientGroup = System.getenv("AWE_CLIENTGROUP");
@@ -276,8 +280,8 @@ public class SDKLocalMethodRunner {
             final URL callbackUrl = CallbackServer.
                     getCallbackUrl(callbackPort);
             if (callbackUrl != null) {
-                System.out.println("Job runner recieved callback URL: " +
-                        callbackUrl);
+                log.logNextLine("Job runner recieved callback URL: " +
+                        callbackUrl, false);
                 final ModuleRunVersion runver = new ModuleRunVersion(
                         new URL(mv.getGitUrl()), modMeth,
                         mv.getGitCommitHash(), mv.getVersion(),
@@ -297,8 +301,9 @@ public class SDKLocalMethodRunner {
                 srvContext.addServlet(new ServletHolder(callback),"/*");
                 callbackServer.start();
             } else {
-                System.out.println("WARNING: No callback URL was recieved " +
-                        "by the job runner. Local callbacks are disabled.");
+                log.logNextLine("WARNING: No callback URL was recieved " +
+                        "by the job runner. Local callbacks are disabled.",
+                        true);
             }
             // Calling Docker run
             new DockerRunner(dockerURI).run(
@@ -356,10 +361,14 @@ public class SDKLocalMethodRunner {
             PrintWriter pw = new PrintWriter(sw);
             ex.printStackTrace(pw);
             pw.close();
-            String stacktrace = sw.toString();
+            String err = "Fatal error: " + sw.toString();
+            if (ex instanceof ServerException) {
+                err += "\nServer exception:\n" +
+                        ((ServerException)ex).getData();
+            }
             try {
                 if (log != null)
-                    log.logNextLine("Fatal error: " + stacktrace, true);
+                    log.logNextLine(err, true);
                 flushLog(jobSrvClient, jobId, logLines);
                 logFlusher.interrupt();
             } catch (Exception ignore) {}
@@ -367,7 +376,7 @@ public class SDKLocalMethodRunner {
                 FinishJobParams result = new FinishJobParams().withError(
                         new JsonRpcError().withCode(-1L).withName("JSONRPCError")
                         .withMessage("Job service side error: " + ex.getMessage())
-                        .withError(stacktrace));
+                        .withError(err));
                 jobSrvClient.finishJob(jobId, result);
             } catch (Exception ex2) {
                 ex2.printStackTrace();
@@ -377,7 +386,7 @@ public class SDKLocalMethodRunner {
                 if (status.length() > 200)
                     status = status.substring(0, 197) + "...";
                 ujsClient.completeJob(jobId, token.toString(), status,
-                        stacktrace, null);
+                        err, null);
             }
         } finally {
             if (callbackServer != null)


### PR DESCRIPTION
AWE may restart failed jobs, in which case the job will already be in a
started state.

If so, just continue.

If the job is not in the started state, throw an error.

In any case, log the error.