### PR TITLE
Use UJS.cancelJob method to cancel jobs

### DIFF
--- a/src/us/kbase/common/executionengine/CallbackServer.java
+++ b/src/us/kbase/common/executionengine/CallbackServer.java
@@ -131,7 +131,7 @@ public abstract class CallbackServer extends JsonServerServlet {
            sas.add(new SubAction()
                .withCodeUrl(mrv.getGitURL().toExternalForm())
                .withCommit(mrv.getGitHash())
-               .withName(mrv.getModuleMethod().getModuleDotMethod())
+               .withName(mrv.getModuleMethod().getModule())
                .withVer(mrv.getVersionAndRelease()));
         }
         return new LinkedList<ProvenanceAction>(Arrays.asList(
@@ -154,9 +154,9 @@ public abstract class CallbackServer extends JsonServerServlet {
         return new UObject(data);
     }
 
-    protected static void cbLog(String log) {
-        System.out.println(String.format("%.2f - CallbackServer: %s",
-                (System.currentTimeMillis() / 1000.0), log));
+    protected void cbLog(String log) {
+        config.getLogger().logNextLine(String.format("%.2f - CallbackServer: %s",
+                (System.currentTimeMillis() / 1000.0), log), false);
     }
     
     protected void processRpcCall(RpcCallData rpcCallData, String token, JsonServerSyslog.RpcInfo info, 
@@ -462,15 +462,16 @@ public abstract class CallbackServer extends JsonServerServlet {
     public static URL getCallbackUrl(int callbackPort)
             throws SocketException {
         final List<String> hostIps = NetUtils.findNetworkAddresses(
-                "docker0", "vboxnet0", "vboxnet1", "VirtualBox Host-Only Ethernet Adapter");
+                "docker0", "vboxnet0", "vboxnet1",
+                "VirtualBox Host-Only Ethernet Adapter");
         final String hostIp;
         if (hostIps.isEmpty()) {
             return null;
         } else {
             hostIp = hostIps.get(0);
             if (hostIps.size() > 1) {
-                cbLog("WARNING! Several Docker host IP addresses " +
-                        "detected, used first:  " + hostIp);
+                System.out.println("WARNING! Several Docker host IP " +
+                        "addresses detected, used first:  " + hostIp);
             }
         }
         try {

--- a/src/us/kbase/common/executionengine/CallbackServer.java
+++ b/src/us/kbase/common/executionengine/CallbackServer.java
@@ -462,7 +462,7 @@ public abstract class CallbackServer extends JsonServerServlet {
     public static URL getCallbackUrl(int callbackPort)
             throws SocketException {
         final List<String> hostIps = NetUtils.findNetworkAddresses(
-                "docker0", "vboxnet0", "vboxnet1");
+                "docker0", "vboxnet0", "vboxnet1", "VirtualBox Host-Only Ethernet Adapter");
         final String hostIp;
         if (hostIps.isEmpty()) {
             return null;

--- a/src/us/kbase/common/service/Tuple13.java
+++ b/src/us/kbase/common/service/Tuple13.java
@@ -1,0 +1,207 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple13 <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private T4 e4;
+    private T5 e5;
+    private T6 e6;
+    private T7 e7;
+    private T8 e8;
+    private T9 e9;
+    private T10 e10;
+    private T11 e11;
+    private T12 e12;
+    private T13 e13;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    public T4 getE4() {
+        return e4;
+    }
+
+    public void setE4(T4 e4) {
+        this.e4 = e4;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE4(T4 e4) {
+        this.e4 = e4;
+        return this;
+    }
+
+    public T5 getE5() {
+        return e5;
+    }
+
+    public void setE5(T5 e5) {
+        this.e5 = e5;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE5(T5 e5) {
+        this.e5 = e5;
+        return this;
+    }
+
+    public T6 getE6() {
+        return e6;
+    }
+
+    public void setE6(T6 e6) {
+        this.e6 = e6;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE6(T6 e6) {
+        this.e6 = e6;
+        return this;
+    }
+
+    public T7 getE7() {
+        return e7;
+    }
+
+    public void setE7(T7 e7) {
+        this.e7 = e7;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE7(T7 e7) {
+        this.e7 = e7;
+        return this;
+    }
+
+    public T8 getE8() {
+        return e8;
+    }
+
+    public void setE8(T8 e8) {
+        this.e8 = e8;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE8(T8 e8) {
+        this.e8 = e8;
+        return this;
+    }
+
+    public T9 getE9() {
+        return e9;
+    }
+
+    public void setE9(T9 e9) {
+        this.e9 = e9;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE9(T9 e9) {
+        this.e9 = e9;
+        return this;
+    }
+
+    public T10 getE10() {
+        return e10;
+    }
+
+    public void setE10(T10 e10) {
+        this.e10 = e10;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE10(T10 e10) {
+        this.e10 = e10;
+        return this;
+    }
+
+    public T11 getE11() {
+        return e11;
+    }
+
+    public void setE11(T11 e11) {
+        this.e11 = e11;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE11(T11 e11) {
+        this.e11 = e11;
+        return this;
+    }
+
+    public T12 getE12() {
+        return e12;
+    }
+
+    public void setE12(T12 e12) {
+        this.e12 = e12;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE12(T12 e12) {
+        this.e12 = e12;
+        return this;
+    }
+
+    public T13 getE13() {
+        return e13;
+    }
+
+    public void setE13(T13 e13) {
+        this.e13 = e13;
+    }
+
+    public Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> withE13(T13 e13) {
+        this.e13 = e13;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple13 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + ", e4=" + e4 + ", e5=" + e5 + ", e6=" + e6 + ", e7=" + e7 + ", e8=" + e8 + ", e9=" + e9 + ", e10=" + e10 + ", e11=" + e11 + ", e12=" + e12 + ", e13=" + e13 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -331,12 +331,12 @@ public class SDKMethodRunner {
                             "%s. Server stacktrace:\n%s",
                             ujsJobId, jobstage, se.getData()), se);
         }
-	    updateAweTaskExecTime(ujsJobId, config, false);
-	    return ret;
-	}
-	
-	public static void finishJob(String ujsJobId, FinishJobParams params, 
-	        AuthToken auth, ErrorLogger log, Map<String, String> config) throws Exception {
+        updateAweTaskExecTime(ujsJobId, config, false);
+        return ret;
+    }
+
+    public static void finishJob(String ujsJobId, FinishJobParams params, 
+            AuthToken auth, ErrorLogger log, Map<String, String> config) throws Exception {
         UserAndJobStateClient ujsClient = getUjsClient(auth, config);
         String jobOwner = ujsClient.getJobOwner(ujsJobId);
         if (auth == null || !jobOwner.equals(auth.getClientId()))
@@ -350,19 +350,28 @@ public class SDKMethodRunner {
                     .withIsError(1L));
             addJobLogs(ujsJobId, lines, auth, config);
             return;
+        } else if (jobStatus.getE2().equals("created")) {
+            // job hasn't started yet. Need to put it in started state to
+            // complete it
+            try {
+                ujsClient.startJob(ujsJobId, auth.toString(),
+                        "starting job so that it can be finished", "as state",
+                        new InitProgress().withPtype("none"), null);
+            } catch (ServerException se) {
+                // ignore and continue if the job was just started
+            }
         }
-		@SuppressWarnings("unchecked")
-		final Map<String, Object> jobOutput =
-				UObject.transformObjectToObject(params, Map.class);
-		//should never trigger since the local method runner limits uploads to
-		//15k
-		checkObjectLength(jobOutput, MAX_PARAM_B, "Output", ujsJobId);
-		SanitizeMongoObject.sanitize(jobOutput);
-		getDb(config).addExecTaskResult(ujsJobId, jobOutput);
-		updateAweTaskExecTime(ujsJobId, config, true);
-		// Updating UJS job state
-		boolean isCancelled = params.getIsCancelled() != null && params.getIsCancelled() == 1L;
-		if (params.getError() != null) {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> jobOutput =
+                UObject.transformObjectToObject(params, Map.class);
+        //should never trigger since the local method runner limits uploads to
+        //15k
+        checkObjectLength(jobOutput, MAX_PARAM_B, "Output", ujsJobId);
+        SanitizeMongoObject.sanitize(jobOutput);
+        getDb(config).addExecTaskResult(ujsJobId, jobOutput);
+        updateAweTaskExecTime(ujsJobId, config, true);
+        // Updating UJS job state
+        if (params.getError() != null) {
             String status = params.getError().getMessage();
             if (status == null)
                 status = "Unknown error";
@@ -370,59 +379,60 @@ public class SDKMethodRunner {
                 status = status.substring(0, 197) + "...";
             ujsClient.completeJob(ujsJobId, auth.toString(), status,
                     params.getError().getError(), null);
-		} else {
-		    String status = isCancelled ? "cancelled" : "done";
-		    ujsClient.completeJob(ujsJobId, auth.toString(), status, null,
-		            new Results());
-		}
-		if (isCancelled)
-		    return;
-		// let's make a call to catalog sending execution stats
-		try {
-			final AppInfo info = getAppInfo(ujsJobId, config);
-			final RunJobParams input = getJobInput(ujsJobId, config);
-			String[] parts = input.getMethod().split(Pattern.quote("."));
-			String funcModuleName = parts.length > 1 ? parts[0] : null;
-			String funcName = parts.length > 1 ? parts[1] : parts[0];
-			String gitCommitHash = input.getServiceVer();
-			Long[] execTimes = getAweTaskExecTimes(ujsJobId, config);
-			long creationTime = execTimes[0];
-			long execStartTime = execTimes[1];
-			long finishTime = execTimes[2];
-			boolean isError = params.getError() != null;
-			String errorMessage = null;
-			try {
-				sendExecStatsToCatalog(auth.getClientId(), info.uiModuleName,
-						info.methodSpecId, funcModuleName, funcName,
-						gitCommitHash, creationTime, execStartTime, finishTime,
-						isError, config);
-			} catch (ServerException ex) {
-				errorMessage = ex.getData();
-				if (errorMessage == null)
-					errorMessage = ex.getMessage();
-				if (errorMessage == null)
-					errorMessage = "Unknown server error";
-			} catch (Exception ex) {
-				errorMessage = ex.getMessage();
-				if (errorMessage == null)
-					errorMessage = "Unknown error";
-			}
-			if (errorMessage != null) {
-				String message = "Error sending execution stats to catalog (" + 
-				        auth.getClientId() + ", " + info.uiModuleName + ", " + info.methodSpecId + 
-				        ", " + funcModuleName + ", " + funcName + ", " + gitCommitHash + ", " + 
-				        creationTime + ", " + execStartTime + ", " + finishTime + ", " + isError + 
-				        "): " + errorMessage;
-				System.err.println(message);
-				if (log != null)
-					log.logErr(message);
-			}
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			if (log != null)
-				log.logErr(ex);
-		}
-	}
+        } else if (params.getIsCancelled() != null &&
+                params.getIsCancelled() == 1L) {
+            ujsClient.cancelJob(ujsJobId, "cancelled by user");
+            return;
+        } else {
+            ujsClient.completeJob(ujsJobId, auth.toString(), "done", null,
+                    new Results());
+        }
+        // let's make a call to catalog sending execution stats
+        try {
+            final AppInfo info = getAppInfo(ujsJobId, config);
+            final RunJobParams input = getJobInput(ujsJobId, config);
+            String[] parts = input.getMethod().split(Pattern.quote("."));
+            String funcModuleName = parts.length > 1 ? parts[0] : null;
+            String funcName = parts.length > 1 ? parts[1] : parts[0];
+            String gitCommitHash = input.getServiceVer();
+            Long[] execTimes = getAweTaskExecTimes(ujsJobId, config);
+            long creationTime = execTimes[0];
+            long execStartTime = execTimes[1];
+            long finishTime = execTimes[2];
+            boolean isError = params.getError() != null;
+            String errorMessage = null;
+            try {
+                sendExecStatsToCatalog(auth.getClientId(), info.uiModuleName,
+                        info.methodSpecId, funcModuleName, funcName,
+                        gitCommitHash, creationTime, execStartTime, finishTime,
+                        isError, config);
+            } catch (ServerException ex) {
+                errorMessage = ex.getData();
+                if (errorMessage == null)
+                    errorMessage = ex.getMessage();
+                if (errorMessage == null)
+                    errorMessage = "Unknown server error";
+            } catch (Exception ex) {
+                errorMessage = ex.getMessage();
+                if (errorMessage == null)
+                    errorMessage = "Unknown error";
+            }
+            if (errorMessage != null) {
+                String message = "Error sending execution stats to catalog (" + 
+                        auth.getClientId() + ", " + info.uiModuleName + ", " + info.methodSpecId + 
+                        ", " + funcModuleName + ", " + funcName + ", " + gitCommitHash + ", " + 
+                        creationTime + ", " + execStartTime + ", " + finishTime + ", " + isError + 
+                        "): " + errorMessage;
+                System.err.println(message);
+                if (log != null)
+                    log.logErr(message);
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            if (log != null)
+                log.logErr(ex);
+        }
+    }
 
 	private static void sendExecStatsToCatalog(String userId, String uiModuleName,
 			String methodSpecId, String funcModuleName, String funcName, String gitCommitHash, 

--- a/src/us/kbase/narrativejobservice/subjobs/NJSCallbackServer.java
+++ b/src/us/kbase/narrativejobservice/subjobs/NJSCallbackServer.java
@@ -67,8 +67,8 @@ public class NJSCallbackServer extends CallbackServer {
                 new LineLogger() {
                     @Override
                     public void logNextLine(String line, boolean isError) {
-                        cbLog("Docker logger std" + (isError ? "err" : "out") +
-                                ": " + line);
+                        System.out.println("Docker logger std" +
+                                (isError ? "err" : "out") + ": " + line);
                     }
                 })
                 .withDockerURI(new URI("unix:///var/run/docker.sock"))

--- a/src/us/kbase/narrativejobservice/test/AweClientDockerJobScriptTest.java
+++ b/src/us/kbase/narrativejobservice/test/AweClientDockerJobScriptTest.java
@@ -845,7 +845,7 @@ public class AweClientDockerJobScriptTest {
             assertThat("correct code url", got.getCodeUrl(),
                     is("https://github.com/kbasetest/" + sa.module));
             assertThat("correct commit", got.getCommit(), is(sa.commit));
-            assertThat("correct name", got.getName(), is(sa.module + ".run"));
+            assertThat("correct name", got.getName(), is(sa.module));
             assertThat("correct version", got.getVer(), is(sa.getVerRel()));
         }
     }

--- a/src/us/kbase/narrativejobservice/test/AweClientDockerJobScriptTest.java
+++ b/src/us/kbase/narrativejobservice/test/AweClientDockerJobScriptTest.java
@@ -73,7 +73,7 @@ import us.kbase.common.service.JsonServerMethod;
 import us.kbase.common.service.JsonServerServlet;
 import us.kbase.common.service.ServerException;
 import us.kbase.common.service.Tuple11;
-import us.kbase.common.service.Tuple12;
+import us.kbase.common.service.Tuple13;
 import us.kbase.common.service.Tuple2;
 import us.kbase.common.service.Tuple3;
 import us.kbase.common.service.UObject;
@@ -204,15 +204,15 @@ public class AweClientDockerJobScriptTest {
             assertThat("incorrect appid", params.getAppId(), is("myapp/foo"));
             
             //check UJS job
-            Tuple12<String, String, String, String,
+            Tuple13<String, Tuple2<String, String>, String, String, String,
                 Tuple3<String, String, String>, Tuple3<Long, Long, String>,
                 Long, Long, Tuple2<String, String>, Map<String, String>,
                 String, Results> u = getUJSClient(token, loadConfig())
                     .getJobInfo2(jobId);
-            assertThat("incorrect metadata", u.getE10(), is(meta));
-            assertThat("incorrect auth strat", u.getE9().getE1(),
+            assertThat("incorrect metadata", u.getE11(), is(meta));
+            assertThat("incorrect auth strat", u.getE10().getE1(),
                     is("kbaseworkspace"));
-            assertThat("incorrect ws id", u.getE9().getE2(),
+            assertThat("incorrect ws id", u.getE10().getE2(),
                     is("" + testWsID));
         } catch (ServerException ex) {
             System.err.println(ex.getData());

--- a/src/us/kbase/narrativejobservice/test/CallbackServerTest.java
+++ b/src/us/kbase/narrativejobservice/test/CallbackServerTest.java
@@ -672,7 +672,7 @@ public class CallbackServerTest {
             assertThat("correct code url", got.getCodeUrl(),
                     is("https://github.com/kbasetest/" + sa.module));
             assertThat("correct commit", got.getCommit(), is(sa.commit));
-            assertThat("correct name", got.getName(), is(sa.module + ".run"));
+            assertThat("correct name", got.getName(), is(sa.module));
             assertThat("correct version", got.getVer(), is(sa.getVerRel()));
         }
     }

--- a/src/us/kbase/userandjobstate/Result.java
+++ b/src/us/kbase/userandjobstate/Result.java
@@ -1,0 +1,124 @@
+
+package us.kbase.userandjobstate;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Result</p>
+ * <pre>
+ * A place where the results of a job may be found.
+ * All fields except description are required.
+ * string server_type - the type of server storing the results. Typically
+ *         either "Shock" or "Workspace". No more than 100 characters.
+ * string url - the url of the server. No more than 1000 characters.
+ * string id - the id of the result in the server. Typically either a
+ *         workspace id or a shock node. No more than 1000 characters.
+ * string description - a free text description of the result.
+ *          No more than 1000 characters.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "server_type",
+    "url",
+    "id",
+    "description"
+})
+public class Result {
+
+    @JsonProperty("server_type")
+    private String serverType;
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("description")
+    private String description;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("server_type")
+    public String getServerType() {
+        return serverType;
+    }
+
+    @JsonProperty("server_type")
+    public void setServerType(String serverType) {
+        this.serverType = serverType;
+    }
+
+    public Result withServerType(String serverType) {
+        this.serverType = serverType;
+        return this;
+    }
+
+    @JsonProperty("url")
+    public String getUrl() {
+        return url;
+    }
+
+    @JsonProperty("url")
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Result withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Result withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Result withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((("Result"+" [serverType=")+ serverType)+", url=")+ url)+", id=")+ id)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/src/us/kbase/userandjobstate/Results.java
+++ b/src/us/kbase/userandjobstate/Results.java
@@ -18,13 +18,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A pointer to job results. All arguments are optional. Applications
  * should use the default shock and workspace urls if omitted.
  * list<string> shocknodes - the shocknode(s) where the results can be
- *         found.
+ *         found. No more than 1000 characters.
  * string shockurl - the url of the shock service where the data was
- *         saved.
+ *         saved.  No more than 1000 characters.
  * list<string> workspaceids - the workspace ids where the results can be
- *         found.
+ *         found. No more than 1000 characters.
  * string workspaceurl - the url of the workspace service where the data
- *         was saved.
+ *         was saved.  No more than 1000 characters.
+ * list<Result> - a set of job results. This format allows for specifying
+ *         results at multiple server locations and providing a free text
+ *         description of the result.
  * </pre>
  * 
  */
@@ -34,7 +37,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "shocknodes",
     "shockurl",
     "workspaceids",
-    "workspaceurl"
+    "workspaceurl",
+    "results"
 })
 public class Results {
 
@@ -46,6 +50,8 @@ public class Results {
     private List<String> workspaceids;
     @JsonProperty("workspaceurl")
     private java.lang.String workspaceurl;
+    @JsonProperty("results")
+    private List<Result> results;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("shocknodes")
@@ -108,6 +114,21 @@ public class Results {
         return this;
     }
 
+    @JsonProperty("results")
+    public List<Result> getResults() {
+        return results;
+    }
+
+    @JsonProperty("results")
+    public void setResults(List<Result> results) {
+        this.results = results;
+    }
+
+    public Results withResults(List<Result> results) {
+        this.results = results;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -120,7 +141,7 @@ public class Results {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((("Results"+" [shocknodes=")+ shocknodes)+", shockurl=")+ shockurl)+", workspaceids=")+ workspaceids)+", workspaceurl=")+ workspaceurl)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((("Results"+" [shocknodes=")+ shocknodes)+", shockurl=")+ shockurl)+", workspaceids=")+ workspaceids)+", workspaceurl=")+ workspaceurl)+", results=")+ results)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/src/us/kbase/userandjobstate/UserAndJobStateClient.java
+++ b/src/us/kbase/userandjobstate/UserAndJobStateClient.java
@@ -12,7 +12,7 @@ import us.kbase.auth.AuthToken;
 import us.kbase.common.service.JsonClientCaller;
 import us.kbase.common.service.JsonClientException;
 import us.kbase.common.service.RpcContext;
-import us.kbase.common.service.Tuple12;
+import us.kbase.common.service.Tuple13;
 import us.kbase.common.service.Tuple14;
 import us.kbase.common.service.Tuple2;
 import us.kbase.common.service.Tuple3;
@@ -86,6 +86,7 @@ import us.kbase.common.service.UnauthorizedException;
  */
 public class UserAndJobStateClient {
     private JsonClientCaller caller;
+    private String serviceVersion = null;
     private static URL DEFAULT_URL = null;
     static {
         try {
@@ -238,6 +239,14 @@ public class UserAndJobStateClient {
         caller.setFileForNextRpcResponse(f);
     }
 
+    public String getServiceVersion() {
+        return this.serviceVersion;
+    }
+
+    public void setServiceVersion(String newValue) {
+        this.serviceVersion = newValue;
+    }
+
     /**
      * <p>Original spec-file function name: ver</p>
      * <pre>
@@ -250,7 +259,7 @@ public class UserAndJobStateClient {
     public String ver(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.ver", args, retType, true, false, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.ver", args, retType, true, false, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -271,7 +280,7 @@ public class UserAndJobStateClient {
         args.add(key);
         args.add(value);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.set_state", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.set_state", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -291,7 +300,7 @@ public class UserAndJobStateClient {
         args.add(key);
         args.add(value);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.set_state_auth", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.set_state_auth", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -312,7 +321,7 @@ public class UserAndJobStateClient {
         args.add(key);
         args.add(auth);
         TypeReference<List<UObject>> retType = new TypeReference<List<UObject>>() {};
-        List<UObject> res = caller.jsonrpcCall("UserAndJobState.get_state", args, retType, true, true, jsonRpcContext);
+        List<UObject> res = caller.jsonrpcCall("UserAndJobState.get_state", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -334,7 +343,7 @@ public class UserAndJobStateClient {
         args.add(key);
         args.add(auth);
         TypeReference<List<Long>> retType = new TypeReference<List<Long>>() {};
-        List<Long> res = caller.jsonrpcCall("UserAndJobState.has_state", args, retType, true, true, jsonRpcContext);
+        List<Long> res = caller.jsonrpcCall("UserAndJobState.has_state", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -358,7 +367,7 @@ public class UserAndJobStateClient {
         args.add(key);
         args.add(auth);
         TypeReference<Tuple2<Long, UObject>> retType = new TypeReference<Tuple2<Long, UObject>>() {};
-        Tuple2<Long, UObject> res = caller.jsonrpcCall("UserAndJobState.get_has_state", args, retType, true, true, jsonRpcContext);
+        Tuple2<Long, UObject> res = caller.jsonrpcCall("UserAndJobState.get_has_state", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res;
     }
 
@@ -377,7 +386,7 @@ public class UserAndJobStateClient {
         args.add(service);
         args.add(key);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.remove_state", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.remove_state", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -395,7 +404,7 @@ public class UserAndJobStateClient {
         args.add(token);
         args.add(key);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.remove_state_auth", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.remove_state_auth", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -414,7 +423,7 @@ public class UserAndJobStateClient {
         args.add(service);
         args.add(auth);
         TypeReference<List<List<String>>> retType = new TypeReference<List<List<String>>>() {};
-        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_state", args, retType, true, true, jsonRpcContext);
+        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_state", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -432,7 +441,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(auth);
         TypeReference<List<List<String>>> retType = new TypeReference<List<List<String>>>() {};
-        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_state_services", args, retType, true, true, jsonRpcContext);
+        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_state_services", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -450,7 +459,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.create_job2", args, retType, true, true, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.create_job2", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -467,7 +476,7 @@ public class UserAndJobStateClient {
     public String createJob(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.create_job", args, retType, true, true, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.create_job", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -494,7 +503,7 @@ public class UserAndJobStateClient {
         args.add(progress);
         args.add(estComplete);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.start_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.start_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -519,7 +528,7 @@ public class UserAndJobStateClient {
         args.add(progress);
         args.add(estComplete);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.create_and_start_job", args, retType, true, true, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.create_and_start_job", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -544,7 +553,7 @@ public class UserAndJobStateClient {
         args.add(prog);
         args.add(estComplete);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.update_job_progress", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.update_job_progress", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -566,7 +575,7 @@ public class UserAndJobStateClient {
         args.add(status);
         args.add(estComplete);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.update_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.update_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -583,7 +592,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<Tuple5<String, String, Long, String, String>> retType = new TypeReference<Tuple5<String, String, Long, String, String>>() {};
-        Tuple5<String, String, Long, String, String> res = caller.jsonrpcCall("UserAndJobState.get_job_description", args, retType, true, true, jsonRpcContext);
+        Tuple5<String, String, Long, String, String> res = caller.jsonrpcCall("UserAndJobState.get_job_description", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res;
     }
 
@@ -593,7 +602,7 @@ public class UserAndJobStateClient {
      * Get the status of a job.
      * </pre>
      * @param   job   instance of original type "job_id" (A job id.)
-     * @return   multiple set: (1) parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), (2) parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', or 'error'.), (3) parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), (4) parameter "progress" of original type "total_progress" (The total progress of a job.), (5) parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), (6) parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), (7) parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.)
+     * @return   multiple set: (1) parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), (2) parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', 'canceled' or 'error'.), (3) parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), (4) parameter "progress" of original type "total_progress" (The total progress of a job.), (5) parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), (6) parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), (7) parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.)
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
@@ -601,7 +610,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<Tuple7<String, String, String, Long, String, Long, Long>> retType = new TypeReference<Tuple7<String, String, String, Long, String, Long, Long>>() {};
-        Tuple7<String, String, String, Long, String, Long, Long> res = caller.jsonrpcCall("UserAndJobState.get_job_status", args, retType, true, true, jsonRpcContext);
+        Tuple7<String, String, String, Long, String, Long, Long> res = caller.jsonrpcCall("UserAndJobState.get_job_status", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res;
     }
 
@@ -628,7 +637,25 @@ public class UserAndJobStateClient {
         args.add(error);
         args.add(res);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.complete_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.complete_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
+    }
+
+    /**
+     * <p>Original spec-file function name: cancel_job</p>
+     * <pre>
+     * Cancel a job.
+     * </pre>
+     * @param   job   instance of original type "job_id" (A job id.)
+     * @param   status   instance of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.)
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public void cancelJob(String job, String status, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(job);
+        args.add(status);
+        TypeReference<Object> retType = new TypeReference<Object>() {};
+        caller.jsonrpcCall("UserAndJobState.cancel_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -645,7 +672,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<List<Results>> retType = new TypeReference<List<Results>>() {};
-        List<Results> res = caller.jsonrpcCall("UserAndJobState.get_results", args, retType, true, true, jsonRpcContext);
+        List<Results> res = caller.jsonrpcCall("UserAndJobState.get_results", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -663,7 +690,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.get_detailed_error", args, retType, true, true, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.get_detailed_error", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -673,15 +700,15 @@ public class UserAndJobStateClient {
      * Get information about a job.
      * </pre>
      * @param   job   instance of original type "job_id" (A job id.)
-     * @return   parameter "info" of original type "job_info2" (Information about a job.) &rarr; tuple of size 12: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', or 'error'.), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "times" of original type "time_info" (Job timing information.) &rarr; tuple of size 3: parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "progress" of original type "progress_info" (Job progress information.) &rarr; tuple of size 3: parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "auth" of original type "auth_info" (Job authorization strategy information.) &rarr; tuple of size 2: parameter "strat" of original type "auth_strategy" (An authorization strategy to use for jobs. Other than the DEFAULT strategy (ACLs local to the UJS and managed by the UJS sharing functions), currently the only other strategy is the 'kbaseworkspace' strategy, which consults the workspace service for authorization information.), parameter "param" of original type "auth_param" (An authorization parameter. The contents of this parameter differ by auth_strategy, but for the workspace strategy it is the workspace id (an integer) as a string.), parameter "meta" of original type "usermeta" (User provided metadata about a job. Arbitrary key-value pairs provided by the user.) &rarr; mapping from String to String, parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
+     * @return   parameter "info" of original type "job_info2" (Information about a job.) &rarr; tuple of size 13: parameter "job" of original type "job_id" (A job id.), parameter "users" of original type "user_info" (Who owns a job and who canceled a job (null if not canceled).) &rarr; tuple of size 2: parameter "owner" of original type "username" (Login name of a KBase user account.), parameter "canceledby" of original type "username" (Login name of a KBase user account.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', 'canceled' or 'error'.), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "times" of original type "time_info" (Job timing information.) &rarr; tuple of size 3: parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "progress" of original type "progress_info" (Job progress information.) &rarr; tuple of size 3: parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "auth" of original type "auth_info" (Job authorization strategy information.) &rarr; tuple of size 2: parameter "strat" of original type "auth_strategy" (An authorization strategy to use for jobs. Other than the DEFAULT strategy (ACLs local to the UJS and managed by the UJS sharing functions), currently the only other strategy is the 'kbaseworkspace' strategy, which consults the workspace service for authorization information.), parameter "param" of original type "auth_param" (An authorization parameter. The contents of this parameter differ by auth_strategy, but for the workspace strategy it is the workspace id (an integer) as a string.), parameter "meta" of original type "usermeta" (User provided metadata about a job. Arbitrary key-value pairs provided by the user.) &rarr; mapping from String to String, parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results> getJobInfo2(String job, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results> getJobInfo2(String job, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
-        TypeReference<List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>> retType = new TypeReference<List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>() {};
-        List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>> res = caller.jsonrpcCall("UserAndJobState.get_job_info2", args, retType, true, true, jsonRpcContext);
+        TypeReference<List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>> retType = new TypeReference<List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>() {};
+        List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>> res = caller.jsonrpcCall("UserAndJobState.get_job_info2", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -692,7 +719,7 @@ public class UserAndJobStateClient {
      * @deprecated get_job_info2
      * </pre>
      * @param   job   instance of original type "job_id" (A job id.)
-     * @return   parameter "info" of original type "job_info" (Information about a job. @deprecated job_info2) &rarr; tuple of size 14: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', or 'error'.), parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
+     * @return   parameter "info" of original type "job_info" (Information about a job. @deprecated job_info2) &rarr; tuple of size 14: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', 'canceled' or 'error'.), parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
@@ -700,7 +727,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>> retType = new TypeReference<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>>() {};
-        List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>> res = caller.jsonrpcCall("UserAndJobState.get_job_info", args, retType, true, true, jsonRpcContext);
+        List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>> res = caller.jsonrpcCall("UserAndJobState.get_job_info", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -710,15 +737,15 @@ public class UserAndJobStateClient {
      * List jobs.
      * </pre>
      * @param   params   instance of type {@link us.kbase.userandjobstate.ListJobsParams ListJobsParams}
-     * @return   parameter "jobs" of list of original type "job_info2" (Information about a job.) &rarr; tuple of size 12: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', or 'error'.), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "times" of original type "time_info" (Job timing information.) &rarr; tuple of size 3: parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "progress" of original type "progress_info" (Job progress information.) &rarr; tuple of size 3: parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "auth" of original type "auth_info" (Job authorization strategy information.) &rarr; tuple of size 2: parameter "strat" of original type "auth_strategy" (An authorization strategy to use for jobs. Other than the DEFAULT strategy (ACLs local to the UJS and managed by the UJS sharing functions), currently the only other strategy is the 'kbaseworkspace' strategy, which consults the workspace service for authorization information.), parameter "param" of original type "auth_param" (An authorization parameter. The contents of this parameter differ by auth_strategy, but for the workspace strategy it is the workspace id (an integer) as a string.), parameter "meta" of original type "usermeta" (User provided metadata about a job. Arbitrary key-value pairs provided by the user.) &rarr; mapping from String to String, parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
+     * @return   parameter "jobs" of list of original type "job_info2" (Information about a job.) &rarr; tuple of size 13: parameter "job" of original type "job_id" (A job id.), parameter "users" of original type "user_info" (Who owns a job and who canceled a job (null if not canceled).) &rarr; tuple of size 2: parameter "owner" of original type "username" (Login name of a KBase user account.), parameter "canceledby" of original type "username" (Login name of a KBase user account.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', 'canceled' or 'error'.), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "times" of original type "time_info" (Job timing information.) &rarr; tuple of size 3: parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "progress" of original type "progress_info" (Job progress information.) &rarr; tuple of size 3: parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "auth" of original type "auth_info" (Job authorization strategy information.) &rarr; tuple of size 2: parameter "strat" of original type "auth_strategy" (An authorization strategy to use for jobs. Other than the DEFAULT strategy (ACLs local to the UJS and managed by the UJS sharing functions), currently the only other strategy is the 'kbaseworkspace' strategy, which consults the workspace service for authorization information.), parameter "param" of original type "auth_param" (An authorization parameter. The contents of this parameter differ by auth_strategy, but for the workspace strategy it is the workspace id (an integer) as a string.), parameter "meta" of original type "usermeta" (User provided metadata about a job. Arbitrary key-value pairs provided by the user.) &rarr; mapping from String to String, parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>> listJobs2(ListJobsParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>> listJobs2(ListJobsParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
-        TypeReference<List<List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>> retType = new TypeReference<List<List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>>() {};
-        List<List<Tuple12<String, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>> res = caller.jsonrpcCall("UserAndJobState.list_jobs2", args, retType, true, true, jsonRpcContext);
+        TypeReference<List<List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>> retType = new TypeReference<List<List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>>>() {};
+        List<List<Tuple13<String, Tuple2<String, String>, String, String, String, Tuple3<String, String, String>, Tuple3<Long, Long, String>, Long, Long, Tuple2<String, String>, Map<String,String>, String, Results>>> res = caller.jsonrpcCall("UserAndJobState.list_jobs2", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -730,8 +757,8 @@ public class UserAndJobStateClient {
      * @deprecated list_jobs2
      * </pre>
      * @param   services   instance of list of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.)
-     * @param   filter   instance of original type "job_filter" (A string-based filter for listing jobs. If the string contains: 'R' - running jobs are returned. 'C' - completed jobs are returned. 'E' - jobs that errored out are returned. 'S' - shared jobs are returned. The string can contain any combination of these codes in any order. If the string contains none of the codes or is null, all self-owned jobs are returned. If only the S filter is present, all jobs are returned. The S filter is ignored for jobs not using the default authorization strategy.)
-     * @return   parameter "jobs" of list of original type "job_info" (Information about a job. @deprecated job_info2) &rarr; tuple of size 14: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', or 'error'.), parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
+     * @param   filter   instance of original type "job_filter" (A string-based filter for listing jobs. If the string contains: 'R' - running jobs are returned. 'C' - completed jobs are returned. 'N' - canceled jobs are returned. 'E' - jobs that errored out are returned. 'S' - shared jobs are returned. The string can contain any combination of these codes in any order. If the string contains none of the codes or is null, all self-owned jobs are returned. If only the S filter is present, all jobs are returned. The S filter is ignored for jobs not using the default authorization strategy.)
+     * @return   parameter "jobs" of list of original type "job_info" (Information about a job. @deprecated job_info2) &rarr; tuple of size 14: parameter "job" of original type "job_id" (A job id.), parameter "service" of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.), parameter "stage" of original type "job_stage" (A string that describes the stage of processing of the job. One of 'created', 'started', 'completed', 'canceled' or 'error'.), parameter "started" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "status" of original type "job_status" (A job status string supplied by the reporting service. No more than 200 characters.), parameter "last_update" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "prog" of original type "total_progress" (The total progress of a job.), parameter "max" of original type "max_progress" (The maximum possible progress of a job.), parameter "ptype" of original type "progress_type" (The type of progress that is being tracked. One of: 'none' - no numerical progress tracking 'task' - Task based tracking, e.g. 3/24 'percent' - percentage based tracking, e.g. 5/100%), parameter "est_complete" of original type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is the difference in time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC time)), parameter "complete" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "error" of original type "boolean" (A boolean. 0 = false, other = true.), parameter "desc" of original type "job_description" (A job description string supplied by the reporting service. No more than 1000 characters.), parameter "res" of type {@link us.kbase.userandjobstate.Results Results}
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
@@ -740,14 +767,16 @@ public class UserAndJobStateClient {
         args.add(services);
         args.add(filter);
         TypeReference<List<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>>> retType = new TypeReference<List<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>>>() {};
-        List<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>> res = caller.jsonrpcCall("UserAndJobState.list_jobs", args, retType, true, true, jsonRpcContext);
+        List<List<Tuple14<String, String, String, String, String, String, Long, Long, String, String, Long, Long, String, Results>>> res = caller.jsonrpcCall("UserAndJobState.list_jobs", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
     /**
      * <p>Original spec-file function name: list_job_services</p>
      * <pre>
-     * List all job services.
+     * List all job services. Note that only services with jobs owned by the
+     * user or shared with the user via the default auth strategy will be
+     * listed.
      * </pre>
      * @return   parameter "services" of list of original type "service_name" (A service name. Alphanumerics and the underscore are allowed.)
      * @throws IOException if an IO exception occurs
@@ -756,7 +785,7 @@ public class UserAndJobStateClient {
     public List<String> listJobServices(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         TypeReference<List<List<String>>> retType = new TypeReference<List<List<String>>>() {};
-        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_job_services", args, retType, true, true, jsonRpcContext);
+        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.list_job_services", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -777,7 +806,7 @@ public class UserAndJobStateClient {
         args.add(job);
         args.add(users);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.share_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.share_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -797,7 +826,7 @@ public class UserAndJobStateClient {
         args.add(job);
         args.add(users);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.unshare_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.unshare_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -814,7 +843,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
-        List<String> res = caller.jsonrpcCall("UserAndJobState.get_job_owner", args, retType, true, true, jsonRpcContext);
+        List<String> res = caller.jsonrpcCall("UserAndJobState.get_job_owner", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -834,14 +863,15 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<List<List<String>>> retType = new TypeReference<List<List<String>>>() {};
-        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.get_job_shared", args, retType, true, true, jsonRpcContext);
+        List<List<String>> res = caller.jsonrpcCall("UserAndJobState.get_job_shared", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
     /**
      * <p>Original spec-file function name: delete_job</p>
      * <pre>
-     * Delete a job. Will fail if the job is not complete.
+     * Delete a job. Will fail if the job is not complete. Only the job owner
+     * can delete a job.
      * </pre>
      * @param   job   instance of original type "job_id" (A job id.)
      * @throws IOException if an IO exception occurs
@@ -851,7 +881,7 @@ public class UserAndJobStateClient {
         List<Object> args = new ArrayList<Object>();
         args.add(job);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.delete_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.delete_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
     }
 
     /**
@@ -859,7 +889,8 @@ public class UserAndJobStateClient {
      * <pre>
      * Force delete a job - will succeed unless the job has not been started.
      * In that case, the service must start the job and then delete it, since
-     * a job is not "owned" by any service until it is started.
+     * a job is not "owned" by any service until it is started. Only the job
+     * owner can delete a job.
      * </pre>
      * @param   token   instance of original type "service_token" (A globus ID token that validates that the service really is said service.)
      * @param   job   instance of original type "job_id" (A job id.)
@@ -871,6 +902,13 @@ public class UserAndJobStateClient {
         args.add(token);
         args.add(job);
         TypeReference<Object> retType = new TypeReference<Object>() {};
-        caller.jsonrpcCall("UserAndJobState.force_delete_job", args, retType, false, true, jsonRpcContext);
+        caller.jsonrpcCall("UserAndJobState.force_delete_job", args, retType, false, true, jsonRpcContext, this.serviceVersion);
+    }
+
+    public Map<String, Object> status(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        TypeReference<List<Map<String, Object>>> retType = new TypeReference<List<Map<String, Object>>>() {};
+        List<Map<String, Object>> res = caller.jsonrpcCall("UserAndJobState.status", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
     }
 }


### PR DESCRIPTION
Uses the UJS cancel job method when a job cancel is requested, which is allowed for anyone with write access to the linked workspace, unlike completeJob.

Also
* synchronize changes in the CallbackServer class from kb_sdk
* CallbackServer now uses the standard logger rather than writing to stdout
* CallbackServer generated provenance no longer includes the (misleading and unnecessary) method name in subactions.