### PR TITLE
 Added extra time for retries and added logic to only check condor for incomplete jobs

### DIFF
--- a/deployment/misc/sdklocalmethodrunner.sh
+++ b/deployment/misc/sdklocalmethodrunner.sh
@@ -3,4 +3,4 @@ JOBID=$1
 KBASE_ENDPOINT=$2
 BASE_DIR=$BASE_DIR/$JOBID
 mkdir -p $BASE_DIR && cd $BASE_DIR
-java -cp "/kb/deployment/lib/*" us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT
+java -cp "/kb/deployment/lib/*" us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr_logs.txt

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -117,7 +117,7 @@ public class CondorUtils {
          * @return String condor job id
          */
 
-        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, adminToken , clientGroups, kbaseEndpoint, baseDir);
+        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, adminToken, clientGroups, kbaseEndpoint, baseDir);
         String[] cmdScript = {"condor_submit", "-spool", "-terse", condorSubmitFile.getAbsolutePath()};
         String jobID = null;
         int retries = 10;

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -140,11 +140,11 @@ public class CondorUtils {
          * @param attribute attribute to search condorQ for
          * @return String condor job attribute or NULL
          */
-        int retries = 1;
+        int retries = 3;
         String result = null;
         String[] cmdScript = new String[]{"/kb/deployment/misc/condor_q.sh", ujsJobId, attribute};
         while (result == null && retries > 0) {
-            Thread.sleep(10);
+            Thread.sleep(10000);
             result = String.join("\n", runProcess(cmdScript).stdout);
             // convert JSON string to Map There has to be a better way than this
             if (result.contains(attribute)) {

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -15,9 +15,10 @@ import java.util.Map;
 
 public class CondorUtils {
 
-    private static File createCondorSubmitFile(String ujsJobId, AuthToken token, String clientGroups, String kbaseEndpoint, String baseDir) throws IOException {
+    private static File createCondorSubmitFile(String ujsJobId, AuthToken token, AuthToken adminToken, String clientGroups, String kbaseEndpoint, String baseDir) throws IOException {
 
-        clientGroups = clientGroupsToRequirements(clientGroups);
+
+        String clientGroupsNew = clientGroupsToRequirements(clientGroups);
         kbaseEndpoint = cleanCondorInputs(kbaseEndpoint);
         String executable = "/kb/deployment/misc/sdklocalmethodrunner.sh";
         String[] args = {ujsJobId, kbaseEndpoint};
@@ -37,8 +38,8 @@ public class CondorUtils {
         csf.add("output = outfile.txt");
         csf.add("error  = errors.txt");
         csf.add("getenv = true");
-        csf.add("requirements = " + clientGroups);
-        csf.add(String.format("environment = \"KB_AUTH_TOKEN=%s BASE_DIR=%s\"", token.getToken(), baseDir));
+        csf.add("requirements = " + clientGroupsNew);
+        csf.add(String.format("environment = \"KB_AUTH_TOKEN=%s KB_ADMIN_AUTH_TOKEN=%s AWE_CLIENTGROUP=%s BASE_DIR=%s\"", token.getToken(), adminToken.getToken(), clientGroups, baseDir));
         csf.add("arguments = " + arguments);
         csf.add("batch_name = " + ujsJobId);
         csf.add("queue 1");
@@ -108,7 +109,7 @@ public class CondorUtils {
                 .replace("\"", "");
     }
 
-    public static String submitToCondorCLI(String ujsJobId, AuthToken token, String clientGroups, String kbaseEndpoint, String baseDir) throws Exception {
+    public static String submitToCondorCLI(String ujsJobId, AuthToken token, String clientGroups, String kbaseEndpoint, String baseDir, AuthToken adminToken) throws Exception {
         /**
          * Call condor_submit with the ujsJobId as batch job name
          * @param jobID ujsJobId to name the batch job with
@@ -116,7 +117,7 @@ public class CondorUtils {
          * @return String condor job id
          */
 
-        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, clientGroups, kbaseEndpoint, baseDir);
+        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, adminToken , clientGroups, kbaseEndpoint, baseDir);
         String[] cmdScript = {"condor_submit", "-spool", "-terse", condorSubmitFile.getAbsolutePath()};
         String jobID = null;
         int retries = 10;
@@ -144,7 +145,7 @@ public class CondorUtils {
         String result = null;
         String[] cmdScript = new String[]{"/kb/deployment/misc/condor_q.sh", ujsJobId, attribute};
         while (result == null && retries > 0) {
-            Thread.sleep(10000);
+            Thread.sleep(5000);
             result = String.join("\n", runProcess(cmdScript).stdout);
             // convert JSON string to Map There has to be a better way than this
             if (result.contains(attribute)) {

--- a/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
@@ -106,9 +106,14 @@ public class DockerRunner {
             }
             cntCmd = cntCmd.withEnv(envVarList.toArray(new String[envVarList.size()]));
 
-            if(! System.getenv("KB_DOCKER_NETWORK").equals("")) {
-                cntCmd.withNetworkMode(System.getenv("KB_DOCKER_NETWORK"));
+            try {
+                String networkMode = System.getenv("KB_DOCKER_NETWORK");
+                if(networkMode != null){
+                    cntCmd.withNetworkMode(networkMode);
+                }
             }
+            catch (Exception ignore){}
+
 
             CreateContainerResponse resp = cntCmd.exec();
             final String cntId = resp.getId();

--- a/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
@@ -106,13 +106,13 @@ public class DockerRunner {
             }
             cntCmd = cntCmd.withEnv(envVarList.toArray(new String[envVarList.size()]));
 
-            try {
-                String networkMode = System.getenv("KB_DOCKER_NETWORK");
-                if(networkMode != null){
-                    cntCmd.withNetworkMode(networkMode);
-                }
-            }
-            catch (Exception ignore){}
+//            try {
+//                String networkMode = System.getenv("KB_DOCKER_NETWORK");
+//                if(networkMode != null){
+//                    cntCmd.withNetworkMode(networkMode);
+//                }
+//            }
+//            catch (Exception ignore){}
 
 
             CreateContainerResponse resp = cntCmd.exec();

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -150,7 +150,7 @@ public class SDKMethodRunner {
 			//TODO MOVE TO CONFIG FILE
 			String baseDir = String.format("/mnt/awe/condor/%s/", authPart.getUserName());
 			String newExternalURL = config.get(NarrativeJobServiceServer.CFG_PROP_SELF_EXTERNAL_URL);
-			String condorID = CondorUtils.submitToCondorCLI(ujsJobId, authPart, aweClientGroups, newExternalURL, baseDir);
+			String condorID = CondorUtils.submitToCondorCLI(ujsJobId, authPart, aweClientGroups, newExternalURL, baseDir, getCatalogAdminAuth(config));
 			addAweTaskDescription(ujsJobId, condorID, jobInput, appJobId, config);
 
 		} else {
@@ -824,22 +824,27 @@ public class SDKMethodRunner {
 				returnVal.setJobState(APP_STATE_DONE);
 			}
 		} else {
-			String condorJobState = getJobState(jobId);
 
-			if (condorJobState == APP_STATE_ERROR) {
-				throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
-						" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?
-						" whereas job script wasn't started at all" : ""));
-			}
-			returnVal.getAdditionalProperties().put("awe_job_state", condorJobState);
-			returnVal.getAdditionalProperties().put("condor_job_state", condorJobState);
+
 			returnVal.setFinished(0L);
 
 			String stage = jobStatus.getE2();
 			if (stage != null && stage.equals("started")) {
 				returnVal.setJobState(APP_STATE_STARTED);
+				//Faking it here
+				returnVal.getAdditionalProperties().put("awe_job_state", APP_STATE_STARTED);
+				returnVal.getAdditionalProperties().put("condor_job_state", APP_STATE_STARTED);
 			} else {
 				returnVal.setJobState(APP_STATE_QUEUED);
+				//Check to see if it is really queued
+//				String condorJobState = getJobState(jobId);
+//
+//				if (condorJobState == APP_STATE_ERROR) {
+//					throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
+//							" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?
+//							" whereas job script wasn't started at all" : ""));
+//				}
+
 				try {
 					String jobPosition = CondorUtils.getJobPriority(jobId);
 					if (jobPosition != null) {

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -648,7 +648,7 @@ public class SDKMethodRunner {
 		 * @return Return an appropriate status constant based on condor status code
 		 */
 		String jobState = CondorUtils.getJobState(ujsJobId);
-		int retries = 1;
+		int retries = 5;
 		if (jobState == null) {
 			while (retries > 0 && jobState == null) {
 				retries--;
@@ -797,10 +797,11 @@ public class SDKMethodRunner {
 										  Map<String, String> config) throws Exception {
 		String ujsUrl = config.get(NarrativeJobServiceServer.CFG_PROP_JOBSTATUS_SRV_URL);
 		JobState returnVal = new JobState().withJobId(jobId).withUjsUrl(ujsUrl);
-		String condorJobState = getJobState(jobId);
 		UserAndJobStateClient ujsClient = getUjsClient(authPart, config);
 		Tuple7<String, String, String, Long, String, Long, Long> jobStatus =
 				ujsClient.getJobStatus(jobId);
+
+
 		returnVal.setStatus(new UObject(jobStatus));
 		boolean complete = jobStatus.getE6() != null && jobStatus.getE6() == 1L;
 		FinishJobParams params = null;
@@ -823,6 +824,8 @@ public class SDKMethodRunner {
 				returnVal.setJobState(APP_STATE_DONE);
 			}
 		} else {
+			String condorJobState = getJobState(jobId);
+
 			if (condorJobState == APP_STATE_ERROR) {
 				throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
 						" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -831,30 +831,10 @@ public class SDKMethodRunner {
 			String stage = jobStatus.getE2();
 			if (stage != null && stage.equals("started")) {
 				returnVal.setJobState(APP_STATE_STARTED);
-				//Faking it here
 				returnVal.getAdditionalProperties().put("awe_job_state", APP_STATE_STARTED);
-				returnVal.getAdditionalProperties().put("condor_job_state", APP_STATE_STARTED);
 			} else {
 				returnVal.setJobState(APP_STATE_QUEUED);
-//				//Check to see if it is really queued
-////				String condorJobState = getJobState(jobId);
-////
-////				if (condorJobState == APP_STATE_ERROR) {
-////					throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
-////							" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?
-////							" whereas job script wasn't started at all" : ""));
-////				}
-//
-//				try {
-//					String jobPosition = CondorUtils.getJobPriority(jobId);
-//					if (jobPosition != null) {
-//						try {
-//							returnVal.setPosition(Long.parseLong(jobPosition));
-//						} catch (Exception ignore) {
-//						}
-//					}
-//				} catch (Exception ignore) {
-//				}
+				returnVal.getAdditionalProperties().put("awe_job_state", APP_STATE_QUEUED);
 			}
 		}
 		Long[] execTimes = getAweTaskExecTimes(jobId, config);

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -648,7 +648,7 @@ public class SDKMethodRunner {
 		 * @return Return an appropriate status constant based on condor status code
 		 */
 		String jobState = CondorUtils.getJobState(ujsJobId);
-		int retries = 5;
+		int retries = 10;
 		if (jobState == null) {
 			while (retries > 0 && jobState == null) {
 				retries--;
@@ -656,7 +656,7 @@ public class SDKMethodRunner {
 			}
 		}
 		if (jobState == null) {
-			return null;
+			return "unavailable";
 		}
 		switch (jobState) {
 			case "0":

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -836,25 +836,25 @@ public class SDKMethodRunner {
 				returnVal.getAdditionalProperties().put("condor_job_state", APP_STATE_STARTED);
 			} else {
 				returnVal.setJobState(APP_STATE_QUEUED);
-				//Check to see if it is really queued
-//				String condorJobState = getJobState(jobId);
+//				//Check to see if it is really queued
+////				String condorJobState = getJobState(jobId);
+////
+////				if (condorJobState == APP_STATE_ERROR) {
+////					throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
+////							" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?
+////							" whereas job script wasn't started at all" : ""));
+////				}
 //
-//				if (condorJobState == APP_STATE_ERROR) {
-//					throw new IllegalStateException("FATAL error in Condor job (" + APP_STATE_ERROR +
-//							" for id=" + jobId + ")" + (jobStatus.getE2().equals("created") ?
-//							" whereas job script wasn't started at all" : ""));
+//				try {
+//					String jobPosition = CondorUtils.getJobPriority(jobId);
+//					if (jobPosition != null) {
+//						try {
+//							returnVal.setPosition(Long.parseLong(jobPosition));
+//						} catch (Exception ignore) {
+//						}
+//					}
+//				} catch (Exception ignore) {
 //				}
-
-				try {
-					String jobPosition = CondorUtils.getJobPriority(jobId);
-					if (jobPosition != null) {
-						try {
-							returnVal.setPosition(Long.parseLong(jobPosition));
-						} catch (Exception ignore) {
-						}
-					}
-				} catch (Exception ignore) {
-				}
 			}
 		}
 		Long[] execTimes = getAweTaskExecTimes(jobId, config);


### PR DESCRIPTION
I added the following logic:
1) Don't check condor if job status is complete in UJS (I thought we always wanted to know the condor state, but this was a wrong assumption)
2) Increase retries again to fight the intermittent condor_q not working problem with condor
3) The retries will not affect narratives with awejobs that have completed, since condor is no longer being checked.
4) Only narratives with AweJobs that are still running at the time of opening the narrative will be slow
5) The fix for 4 is to add a META tag to UJS or add a field to mongo and then write logic based on that to not check the status in condor if it doesn't have the condor flag. (Other fix is to wait until no more awe jobs are running anymore)