### PR TITLE
Fix refdata for subjobs

### DIFF
--- a/src/us/kbase/common/executionengine/CallbackServerConfigBuilder.java
+++ b/src/us/kbase/common/executionengine/CallbackServerConfigBuilder.java
@@ -47,7 +47,7 @@ public class CallbackServerConfigBuilder {
     private URI dockerURI = null;
     final private URL callbackURL;
     final private Path workDir;
-    final private Path refDataDir;
+    final private Path refDataBase;
     final private LineLogger logger;
     
     public CallbackServerConfigBuilder(
@@ -63,7 +63,7 @@ public class CallbackServerConfigBuilder {
             final URL catalogURL,
             final URL callbackURL,
             final Path workDir,
-            final Path refDataDir,
+            final Path refDataBase,
             final LineLogger logger) {
         super();
         checkNulls(kbaseEndpointURL, authServiceURL, callbackURL, workDir, logger);
@@ -80,7 +80,7 @@ public class CallbackServerConfigBuilder {
         this.catalogURL = optionalURL(catalogURL, kbaseEndpointURL, EP_CAT);
         this.callbackURL = callbackURL;
         this.workDir = workDir;
-        this.refDataDir = refDataDir;
+        this.refDataBase = refDataBase;
         this.logger = logger;
     }
     
@@ -88,7 +88,7 @@ public class CallbackServerConfigBuilder {
             final Map<String, String> config,
             final URL callbackURL,
             final Path workDir,
-            final Path refDataDir,
+            final Path refDataBase,
             final LineLogger logger) {
         super();
         checkNulls(config, callbackURL, workDir, logger);
@@ -126,7 +126,7 @@ public class CallbackServerConfigBuilder {
                 true);
         this.callbackURL = callbackURL;
         this.workDir = workDir;
-        this.refDataDir = refDataDir;
+        this.refDataBase = refDataBase;
         this.logger = logger;
     }
     
@@ -140,7 +140,7 @@ public class CallbackServerConfigBuilder {
         return new CallbackServerConfig(
                 kbaseEndpointURL, workspaceURL, shockURL, userJobStateURL, 
                 handleURL, srvWizURL, njswURL, authServiceURL, authAllowInsecure,
-                catalogURL, dockerURI, callbackURL, workDir, refDataDir, logger);
+                catalogURL, dockerURI, callbackURL, workDir, refDataBase, logger);
     }
 
 
@@ -248,12 +248,12 @@ public class CallbackServerConfigBuilder {
         final private URL callbackURL;
         final private Path workDir;
         final private LineLogger logger;
-        final public Path refDataDir;
+        final public Path refDataBase;
 
         private CallbackServerConfig(URL kbaseEndpointURL, URL workspaceURL, URL shockURL, 
                 URL userJobStateURL, URL handleURL, URL srvWizURL, URL njswURL, URL authServiceURL,
                 String authAllowInsecure, URL catalogURL, URI dockerURI, URL callbackURL, 
-                Path workDir, Path refDataDir, LineLogger logger) {
+                Path workDir, Path refDataBase, LineLogger logger) {
             super();
             this.kbaseEndpointURL = kbaseEndpointURL;
             this.workspaceURL = workspaceURL;
@@ -268,7 +268,7 @@ public class CallbackServerConfigBuilder {
             this.dockerURI = dockerURI;
             this.callbackURL = callbackURL;
             this.workDir = workDir;
-            this.refDataDir = refDataDir;
+            this.refDataBase = refDataBase;
             this.logger = logger;
         }
 

--- a/src/us/kbase/common/executionengine/CallbackServerConfigBuilder.java
+++ b/src/us/kbase/common/executionengine/CallbackServerConfigBuilder.java
@@ -47,6 +47,7 @@ public class CallbackServerConfigBuilder {
     private URI dockerURI = null;
     final private URL callbackURL;
     final private Path workDir;
+    final private Path refDataDir;
     final private LineLogger logger;
     
     public CallbackServerConfigBuilder(
@@ -62,6 +63,7 @@ public class CallbackServerConfigBuilder {
             final URL catalogURL,
             final URL callbackURL,
             final Path workDir,
+            final Path refDataDir,
             final LineLogger logger) {
         super();
         checkNulls(kbaseEndpointURL, authServiceURL, callbackURL, workDir, logger);
@@ -78,6 +80,7 @@ public class CallbackServerConfigBuilder {
         this.catalogURL = optionalURL(catalogURL, kbaseEndpointURL, EP_CAT);
         this.callbackURL = callbackURL;
         this.workDir = workDir;
+        this.refDataDir = refDataDir;
         this.logger = logger;
     }
     
@@ -85,6 +88,7 @@ public class CallbackServerConfigBuilder {
             final Map<String, String> config,
             final URL callbackURL,
             final Path workDir,
+            final Path refDataDir,
             final LineLogger logger) {
         super();
         checkNulls(config, callbackURL, workDir, logger);
@@ -122,6 +126,7 @@ public class CallbackServerConfigBuilder {
                 true);
         this.callbackURL = callbackURL;
         this.workDir = workDir;
+        this.refDataDir = refDataDir;
         this.logger = logger;
     }
     
@@ -135,7 +140,7 @@ public class CallbackServerConfigBuilder {
         return new CallbackServerConfig(
                 kbaseEndpointURL, workspaceURL, shockURL, userJobStateURL, 
                 handleURL, srvWizURL, njswURL, authServiceURL, authAllowInsecure,
-                catalogURL, dockerURI, callbackURL, workDir, logger);
+                catalogURL, dockerURI, callbackURL, workDir, refDataDir, logger);
     }
 
 
@@ -243,11 +248,12 @@ public class CallbackServerConfigBuilder {
         final private URL callbackURL;
         final private Path workDir;
         final private LineLogger logger;
+        final public Path refDataDir;
 
         private CallbackServerConfig(URL kbaseEndpointURL, URL workspaceURL, URL shockURL, 
                 URL userJobStateURL, URL handleURL, URL srvWizURL, URL njswURL, URL authServiceURL,
                 String authAllowInsecure, URL catalogURL, URI dockerURI, URL callbackURL, 
-                Path workDir, LineLogger logger) {
+                Path workDir, Path refDataDir, LineLogger logger) {
             super();
             this.kbaseEndpointURL = kbaseEndpointURL;
             this.workspaceURL = workspaceURL;
@@ -262,6 +268,7 @@ public class CallbackServerConfigBuilder {
             this.dockerURI = dockerURI;
             this.callbackURL = callbackURL;
             this.workDir = workDir;
+            this.refDataDir = refDataDir;
             this.logger = logger;
         }
 

--- a/src/us/kbase/common/executionengine/SubsequentCallRunner.java
+++ b/src/us/kbase/common/executionengine/SubsequentCallRunner.java
@@ -40,6 +40,7 @@ public abstract class SubsequentCallRunner {
     private final String imageName;
     private final ModuleRunVersion mrv;
     private final CallbackServerConfig config;
+    private final ModuleVersion moduleVersion;
     
     public SubsequentCallRunner(
             final AuthToken token,
@@ -52,9 +53,9 @@ public abstract class SubsequentCallRunner {
         this.config = config;
         this.moduleName = modmeth.getModule();
         this.jobId = jobId;
-        final ModuleVersion mv = loadModuleVersion(modmeth, serviceVer);
-        mrv =  this.createModuleRunVersion(modmeth, serviceVer, mv);
-        imageName = this.getImageName(mv);
+        moduleVersion = loadModuleVersion(modmeth, serviceVer);
+        mrv =  this.createModuleRunVersion(modmeth, serviceVer, moduleVersion);
+        imageName = this.getImageName(moduleVersion);
         Files.createDirectories(getSharedScratchDir(config));
         final Path jobWorkDir = getJobWorkDir(jobId, config, imageName);
         Files.createDirectories(jobWorkDir);
@@ -124,7 +125,7 @@ public abstract class SubsequentCallRunner {
                 .resolve("input.json");
         UObject.getMapper().writeValue(inputFile.toFile(), rpcCallData);
         final Path outputFile = runModule(jobId, inputFile, config,
-                imageName, moduleName, callToken);
+                imageName, moduleName, moduleVersion, callToken);
         if (Files.exists(outputFile)) {
             final Map<String, Object> jsonRpcResponse = UObject.getMapper().readValue(
                     outputFile.toFile(), new TypeReference<Map<String, Object>>() {});
@@ -193,6 +194,7 @@ public abstract class SubsequentCallRunner {
             final CallbackServerConfig config,
             final String imageName,
             final String moduleName,
+            final ModuleVersion moduleVersion,
             final AuthToken token)
             throws IOException,
             InterruptedException;

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
@@ -367,7 +367,7 @@ public class SDKLocalMethodRunner {
                         requestedRelease);
                 final CallbackServerConfig cbcfg = 
                         new CallbackServerConfigBuilder(config, callbackUrl,
-                                jobDir.toPath(), log).build();
+                                jobDir.toPath(), refDataDir.toPath(), log).build();
                 final JsonServerServlet callback = new NJSCallbackServer(
                         token, cbcfg, runver, job.getParams(),
                         job.getSourceWsObjects(), additionalBinds, cancellationChecker);

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
@@ -11,6 +11,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -214,8 +215,8 @@ public class SDKLocalMethodRunner {
             }
             String imageName = mv.getDockerImgName();
             File refDataDir = null;
+            String refDataBase = config.get(NarrativeJobServiceServer.CFG_PROP_REF_DATA_BASE);
             if (mv.getDataFolder() != null && mv.getDataVersion() != null) {
-                String refDataBase = config.get(NarrativeJobServiceServer.CFG_PROP_REF_DATA_BASE);
                 if (refDataBase == null)
                     throw new IllegalStateException("Reference data parameters are defined for image but " + 
                             NarrativeJobServiceServer.CFG_PROP_REF_DATA_BASE + " property isn't set in configuration");
@@ -367,7 +368,7 @@ public class SDKLocalMethodRunner {
                         requestedRelease);
                 final CallbackServerConfig cbcfg = 
                         new CallbackServerConfigBuilder(config, callbackUrl,
-                                jobDir.toPath(), refDataDir.toPath(), log).build();
+                                jobDir.toPath(), Paths.get(refDataBase), log).build();
                 final JsonServerServlet callback = new NJSCallbackServer(
                         token, cbcfg, runver, job.getParams(),
                         job.getSourceWsObjects(), additionalBinds, cancellationChecker);

--- a/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
+++ b/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
@@ -51,7 +51,7 @@ public class NJSSubsequentCallRunner extends SubsequentCallRunner {
         final Path sharedScratchDir = getSharedScratchDir(config);
         new DockerRunner(config.getDockerURI()).run(
                 imageName, moduleName, inputFile.toFile(), token,
-                config.getLogger(), outputFile.toFile(), false, null,
+                config.getLogger(), outputFile.toFile(), false, config.refDataDir.toFile(),
                 sharedScratchDir.toFile(), config.getCallbackURL(),
                 jobId.toString(), additionalBinds, cancellationChecker, null);
         return outputFile;

--- a/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
+++ b/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
@@ -2,12 +2,14 @@ package us.kbase.narrativejobservice.subjobs;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 
 import com.github.dockerjava.api.model.Bind;
 
 import us.kbase.auth.AuthToken;
+import us.kbase.catalog.ModuleVersion;
 import us.kbase.common.executionengine.ModuleMethod;
 import us.kbase.common.executionengine.SubsequentCallRunner;
 import us.kbase.common.executionengine.CallbackServerConfigBuilder.CallbackServerConfig;
@@ -40,6 +42,7 @@ public class NJSSubsequentCallRunner extends SubsequentCallRunner {
             final CallbackServerConfig config,
             final String imageName,
             final String moduleName,
+            final ModuleVersion moduleVersion,
             final AuthToken token)
             throws IOException, InterruptedException {
         final Path outputFile = getJobWorkDir(jobId, config, imageName)
@@ -49,9 +52,15 @@ public class NJSSubsequentCallRunner extends SubsequentCallRunner {
         config.getLogger().logNextLine(
                 "Running docker container for image: " + imageName, false);
         final Path sharedScratchDir = getSharedScratchDir(config);
+        // Create a refdata path in the format 'dataBase/dataFolder/dataVersion'
+        final Path refDataDir = Paths.get(
+            config.refDataBase.toString(),
+            moduleVersion.getDataFolder(),
+            moduleVersion.getDataVersion()
+        );
         new DockerRunner(config.getDockerURI()).run(
                 imageName, moduleName, inputFile.toFile(), token,
-                config.getLogger(), outputFile.toFile(), false, config.refDataDir.toFile(),
+                config.getLogger(), outputFile.toFile(), false, refDataDir.toFile(),
                 sharedScratchDir.toFile(), config.getCallbackURL(),
                 jobId.toString(), additionalBinds, cancellationChecker, null);
         return outputFile;

--- a/src/us/kbase/narrativejobservice/test/CallbackServerTest.java
+++ b/src/us/kbase/narrativejobservice/test/CallbackServerTest.java
@@ -117,7 +117,7 @@ public class CallbackServerTest {
         final CallbackServerConfig cbcfg =
                 new CallbackServerConfigBuilder(
                 TesterUtils.loadConfig(), callbackUrl,
-                        temp, log).build();
+                        temp, null, log).build();
         final JsonServerServlet callback = new NJSCallbackServer(
                 token, cbcfg, runver, params, wsobjs, null, null);
         final Server callbackServer = new Server(callbackPort);


### PR DESCRIPTION
Added an instance variable in CallbackServiceConfig for refDataDir so that it is accessible from the NJSubsequentJobRunner