### PR TITLE
Add logging that (hopefully) works on CallbackServer exceptions

### DIFF
--- a/src/us/kbase/common/executionengine/CallbackServer.java
+++ b/src/us/kbase/common/executionengine/CallbackServer.java
@@ -3,6 +3,8 @@ package us.kbase.common.executionengine;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.SocketException;
 import java.net.URL;
@@ -200,7 +202,10 @@ public abstract class CallbackServer extends JsonServerServlet {
             try {
                 jsonRpcResponse = handleCall(rpcCallData, token);
             } catch (Exception ex) {
-                ex.printStackTrace();
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                ex.printStackTrace(pw);
+                cbLog(sw.toString());
                 errorMessage = ex.getMessage();
             }
             try {


### PR DESCRIPTION
It looks like `ex.printStackTrace()` didn't log in the narrative -- this changes it to use `cbLog` on a string of the stack trace, which I think has a better chance of working.

I'm still shooting blind as I don't yet have a great way to run any of this locally. It all compiles though :p.