### PR TITLE
Add job label as info to condor_q

### DIFF
--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -26,7 +26,7 @@ public class CondorUtils {
      * @return The generated condor submit file
      * @throws IOException
      */
-    private static File createCondorSubmitFile(String ujsJobId, AuthToken token, AuthToken adminToken, String clientGroups, String kbaseEndpoint, String baseDir) throws IOException {
+    private static File createCondorSubmitFile(String ujsJobId, AuthToken token, AuthToken adminToken, String clientGroups, String kbaseEndpoint, String baseDir, HashMap<String,String> optClassAds) throws IOException {
 
 
         String clientGroupsNew = clientGroupsToRequirements(clientGroups);
@@ -53,6 +53,9 @@ public class CondorUtils {
         csf.add(String.format("environment = \"KB_AUTH_TOKEN=%s KB_ADMIN_AUTH_TOKEN=%s AWE_CLIENTGROUP=%s BASE_DIR=%s\"", token.getToken(), adminToken.getToken(), clientGroups, baseDir));
         csf.add("arguments = " + arguments);
         csf.add("batch_name = " + ujsJobId);
+        for (Map.Entry<String, String> pair: optClassAds.entrySet()) {
+            csf.add(String.format("+%s = \"%s\"", pair.getKey(), pair.getValue()));
+        }
         csf.add("queue 1");
 
         File submitFile = new File(String.format("%s.sub", ujsJobId));
@@ -133,8 +136,8 @@ public class CondorUtils {
      * @return String condor job id Range
      * @throws Exception
      */
-    public static String submitToCondorCLI(String ujsJobId, AuthToken token, String clientGroups, String kbaseEndpoint, String baseDir, AuthToken adminToken) throws Exception {
-        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, adminToken, clientGroups, kbaseEndpoint, baseDir);
+    public static String submitToCondorCLI(String ujsJobId, AuthToken token, String clientGroups, String kbaseEndpoint, String baseDir, HashMap<String,String> optClassAds, AuthToken adminToken) throws Exception {
+        File condorSubmitFile = createCondorSubmitFile(ujsJobId, token, adminToken, clientGroups, kbaseEndpoint, baseDir, optClassAds);
         String[] cmdScript = {"condor_submit", "-spool", "-terse", condorSubmitFile.getAbsolutePath()};
         String jobID = null;
         int retries = 10;

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKMethodRunner.java
@@ -6,14 +6,7 @@ import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,16 +137,22 @@ public class SDKMethodRunner {
 
 		// Config switch to switch to calling new Condor Utils method submitToCondor
 		if (config.get(NarrativeJobServiceServer.CFG_PROP_CONDOR_MODE).equals("1")) {
-			//TODO REMOVE
 			System.out.println("UJS JOB ID FOR SUBMITTED JOB IS:" + ujsJobId);
-			String baseDir = config.get(NarrativeJobServiceServer.CFG_PROP_CONDOR_JOB_DATA_DIR);
-			baseDir = String.format("%s/%s/", baseDir, authPart.getUserName());
+			HashMap<String, String> optClassAds = new HashMap<String, String>();
+			String[] modNameFuncName = params.getMethod().split(Pattern.quote("."));
+			optClassAds.put("kb_parent_job_id", params.getParentJobId());
+			optClassAds.put("kb_module_name", modNameFuncName[0]);
+			optClassAds.put("kb_function_name", modNameFuncName[0]);
+			optClassAds.put("kb_app_id", params.getAppId());
+			optClassAds.put("kb_wsid", "" + params.getWsid().toString());
+
+			String baseDir = String.format("%s/%s/", config.get(NarrativeJobServiceServer.CFG_PROP_CONDOR_JOB_DATA_DIR), authPart.getUserName());
 			String newExternalURL = config.get(NarrativeJobServiceServer.CFG_PROP_SELF_EXTERNAL_URL);
-			String condorId = CondorUtils.submitToCondorCLI(ujsJobId, authPart, aweClientGroups, newExternalURL, baseDir, getCatalogAdminAuth(config));
-			String schedulerType = "condor";
-			String lastJobState = null;
 			String parentJobId = params.getParentJobId();
-			saveTask(ujsJobId, condorId, jobInput, appJobId, "condor", lastJobState, parentJobId, config);
+			String schedulerType = "condor";
+
+			String condorId = CondorUtils.submitToCondorCLI(ujsJobId, authPart, aweClientGroups, newExternalURL, baseDir, optClassAds, getCatalogAdminAuth(config));
+			saveTask(ujsJobId, condorId, jobInput, appJobId, schedulerType,parentJobId, config);
 
 		} else {
 			String aweJobId = AweUtils.runTask(getAweServerURL(config), "ExecutionEngine", params.getMethod(), ujsJobId + " " + selfExternalUrl, NarrativeJobServiceServer.AWE_CLIENT_SCRIPT_NAME, authPart, aweClientGroups, getCatalogAdminAuth(config));
@@ -1079,7 +1078,6 @@ public class SDKMethodRunner {
 	 * @param jobInput (Runjob Params)
 	 * @param appJobId
 	 * @param schedulerType (Scheduler Type, such as Condor or Awe)
-	 * @param lastJobState (Last job state, such as queued)
 	 * @param parentJobId (ID of Parent Job)
 	 * @param config (Configuration File)
 	 * @throws Exception
@@ -1090,7 +1088,6 @@ public class SDKMethodRunner {
 			final Map<String, Object> jobInput,
 			final String appJobId,
 			final String schedulerType,
-			final String lastJobState,
 			final String parentJobId,
 			final Map<String, String> config) throws Exception {
 
@@ -1103,9 +1100,7 @@ public class SDKMethodRunner {
 		dbTask.setAppJobId(appJobId);
 		dbTask.setSchdulerType(schedulerType);
 		dbTask.setTaskId(jobId);
-		dbTask.setLastJobState(lastJobState);
 		dbTask.setParentJobId(parentJobId);
-
 		db.insertExecTask(dbTask);
 	}
 


### PR DESCRIPTION
Since I couldn't add info as a docker label yet, added it as class ads. 
Here is an example
```
kbase@346531c2654e:/kb/deployment/jettybase$ condor_q  -af:jlh JobBatchName kb_parent_job_id kb_module_name kb_function_name kb_app_id kb_wsid
 ID           JobBatchName             kb_parent_job_id         kb_module_name kb_function_name kb_app_id kb_wsid
ID =    1.0   5b15911ce4b02b1e7cde218e null                     simpleapp      simpleapp        myapp/foo 1
ID =    2.0   5b159128e4b02b1e7cde218f null                     simpleapp      simpleapp        myapp/foo 1
ID =    3.0   5b15912ae4b02b1e7cde2190 5b159128e4b02b1e7cde218f simpleapp      simpleapp        myapp/foo 1
ID =    4.0   5b15912ce4b02b1e7cde2191 5b159128e4b02b1e7cde218f simpleapp      simpleapp        myapp/foo 1
ID =    5.0   5b15912ee4b02b1e7cde2192 null                     simpleapp      simpleapp        myapp/foo 1
ID =    6.0   5b1593f5e4b02b1e7cde2193 null                     simpleapp      simpleapp        myapp/foo 2
ID =    7.0   5b159401e4b02b1e7cde2194 null                     simpleapp      simpleapp        myapp/foo 2
ID =    8.0   5b159402e4b02b1e7cde2195 5b159401e4b02b1e7cde2194 simpleapp      simpleapp        myapp/foo 2
ID =    9.0   5b159404e4b02b1e7cde2196 5b159401e4b02b1e7cde2194 simpleapp      simpleapp        myapp/foo 2
ID =   10.0   5b159406e4b02b1e7cde2197 null                     simpleapp      simpleapp        myapp/foo 2
```