### PR TITLE
SCT-1105 Add docker resource options

### DIFF
--- a/deployment/misc/sdklocalmethodrunner.sh
+++ b/deployment/misc/sdklocalmethodrunner.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
+if [ -e /etc/clustername ] ; then
+  echo "NERSC"
+  HOME=/global/homes/k/kbaserun
+  $HOME/bin/run_async_srv_method.sh $@
+else
+#export MINI_KB=true
+NJSW_JAR=`readlink -f NJSWrapper-all.jar`
 JOBID=$1
 KBASE_ENDPOINT=$2
 BASE_DIR=$BASE_DIR/$JOBID
 mkdir -p $BASE_DIR && cd $BASE_DIR
-java -cp "/kb/deployment/lib/NJSWrapper-all.jar" us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err
+echo "Jar Location = $NJSW_JAR" > jar
+java -cp $NJSW_JAR us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err
+fi

--- a/deployment/misc/sdklocalmethodrunner_dev.sh
+++ b/deployment/misc/sdklocalmethodrunner_dev.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
+if [ -e /etc/clustername ] ; then
+  echo "NERSC"
+  HOME=/global/homes/k/kbaserun
+  $HOME/bin/run_async_srv_method.sh $@
+else
 export MINI_KB=true
 NJSW_JAR=`readlink -f NJSWrapper-all.jar`
 JOBID=$1
 KBASE_ENDPOINT=$2
 BASE_DIR=$BASE_DIR/$JOBID
 mkdir -p $BASE_DIR && cd $BASE_DIR
-echo "Jar Location = $NJSW_JAR" >> jar
-java -cp $NJSW_JAR us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err
+echo "Jar Location = $NJSW_JAR" > jar
+java -cp $NJSW_JAR us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err
+fi

--- a/deployment/misc/sdklocalmethodrunner_dev.sh
+++ b/deployment/misc/sdklocalmethodrunner_dev.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+export MINI_KB=true
+NJSW_JAR=`readlink -f NJSWrapper-all.jar`
 JOBID=$1
 KBASE_ENDPOINT=$2
 BASE_DIR=$BASE_DIR/$JOBID
-export MINI_KB=true
 mkdir -p $BASE_DIR && cd $BASE_DIR
-java -cp "/kb/deployment/lib/dist/NJSWrapper-all.jar" us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err
+echo "Jar Location = $NJSW_JAR" >> jar
+java -cp $NJSW_JAR us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err.sdkjobs.SDKLocalMethodRunner $JOBID $KBASE_ENDPOINT > sdk_lmr.out 2> sdk_lmr.err

--- a/dev_tools/simple_mini_kb_deploy.sh
+++ b/dev_tools/simple_mini_kb_deploy.sh
@@ -1,62 +1,26 @@
-[NarrativeJobService]
-port = 8200
-# server thread count - this determines the number of requests that can be
-# processed simultaneously.
-server-threads = 20
-# Minimum memory size in MB.
-min-memory = 1000
-# Maximum memory size in MB.
-max-memory = 1500
+#!/usr/bin/env bash
+njs=`docker ps | grep mini_kb_njs_1 | cut -f1 -d' '`
+docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper-all.jar $njs:/kb/deployment/lib/
+docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper.war $njs:/kb/deployment/jettybase/webapps/root.war
+docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $njs:/kb/deployment/misc/
 
-queue.db.dir=/tmp/njs/queue
-basedir=njs_wrapper
-scratch=/tmp
-ref.data.base=/kb/data
+#max=`docker ps | grep mini_kb_condor_worker_max | cut -f1 -d' ' | head -n1`
+#min=`docker ps | grep mini_kb_condor_worker_mini | cut -f1 -d' ' | head -n1`
 
 
-self.external.url=http://nginx/services/njs
-kbase.endpoint=http://nginx/services
-workspace.srv.url=http://nginx/services/ws
-jobstatus.srv.url=http://nginx/services/ujs
-shock.url=http://nginx/services/shock
-awe.srv.url=
-docker.registry.url=dockerhub-ci.kbase.us
-awe.client.docker.uri=unix:///var/run/docker.sock
-catalog.srv.url=https://ci.kbase.us/services/catalog
-handle.url=http://nginx/services/handle_service
-srv.wiz.url=http://nginx/services/service_wizard
-auth-service-url = http://nginx/services/auth/api/legacy/KBase/Sessions/Login
-auth-service-url-allow-insecure=true
+#docker cp /njs_wrapper/njs_wrapper/dist/ $max:/kb/deployment/lib/
+#docker cp /njs_wrapper/njs_wrapper/dist/ $min:/kb/deployment/lib/
 
-## This user can run list_running_apps method to get states
-## of all running apps (running internally on wrapper side).
-admin.user=
 
-# Following parameters define Catalog admin creds for pushing exec-stats:
-catalog.admin.token=
+#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $njs:/kb/deployment/misc/
 
-default.awe.client.groups=ci
-awe.readonly.admin.token=
-awe.client.callback.networks=docker0,eth0
-running.tasks.per.user=5
+#docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $max:/kb/deployment/misc/
+#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $max:/kb/deployment/misc/
 
-mongodb-host = ci-mongo:27017
-mongodb-database = exec_engine
-mongodb-user = mini_kb
-mongodb-pwd = mini_kb_password
+#docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $min:/kb/deployment/misc/
+#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $min:/kb/deployment/misc/
 
-ujs-mongodb-host = ci-mongo:27017
-ujs-mongodb-database = userjobstate
-ujs-mongodb-user = mini_kb
-ujs-mongodb-pwd = mini_kb_password
 
-narrative.proxy.sharing.user=narrativejoblistener
+Echo "Done"
 
-# This next flag really doesn't make sense to me as a startup option, but copying from CI config
-## Please change next flag before you reboot machine.
-## It will help keep tasks in queue and rerun them later.
-## Don't forget to revert this flag after reboot.
-reboot.mode=false
 
-condor.mode=1
-condor.submit.desc.file.path=../scripts/

--- a/dev_tools/simple_mini_kb_deploy.sh
+++ b/dev_tools/simple_mini_kb_deploy.sh
@@ -1,22 +1,62 @@
-#!/usr/bin/env bash
+[NarrativeJobService]
+port = 8200
+# server thread count - this determines the number of requests that can be
+# processed simultaneously.
+server-threads = 20
+# Minimum memory size in MB.
+min-memory = 1000
+# Maximum memory size in MB.
+max-memory = 1500
 
-njs=`docker ps | grep mini_kb_njs_1 | cut -f1 -d' '`
-max=`docker ps | grep mini_kb_condor_worker_max | cut -f1 -d' '`
-min=`docker ps | grep mini_kb_condor_worker_mini | cut -f1 -d' '`
-
-docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper.jar $njs:/kb/deployment/lib/
-docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper.jar $max:/kb/deployment/lib/
-docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper.jar $min:/kb/deployment/lib/
-docker cp /njs_wrapper/njs_wrapper/dist/NJSWrapper.war $njs:/kb/deployment/jettybase/webapps/root.war
-
-#Optional copy over other dependencies or new sdk_localmethodrunner script
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $njs:/kb/deployment/misc/
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $njs:/kb/deployment/misc/
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $max:/kb/deployment/misc/
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $max:/kb/deployment/misc/
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/sdklocalmethodrunner.sh $min:/kb/deployment/misc/
-#docker cp /njs_wrapper/njs_wrapper/deployment/misc/docker3dependencies $min:/kb/deployment/misc/
-
-echo "Done copying jars/wars/(maybe other things) to /kb/deployment/lib for njs,condor_max,condor_min"
+queue.db.dir=/tmp/njs/queue
+basedir=njs_wrapper
+scratch=/tmp
+ref.data.base=/kb/data
 
 
+self.external.url=http://nginx/services/njs
+kbase.endpoint=http://nginx/services
+workspace.srv.url=http://nginx/services/ws
+jobstatus.srv.url=http://nginx/services/ujs
+shock.url=http://nginx/services/shock
+awe.srv.url=
+docker.registry.url=dockerhub-ci.kbase.us
+awe.client.docker.uri=unix:///var/run/docker.sock
+catalog.srv.url=https://ci.kbase.us/services/catalog
+handle.url=http://nginx/services/handle_service
+srv.wiz.url=http://nginx/services/service_wizard
+auth-service-url = http://nginx/services/auth/api/legacy/KBase/Sessions/Login
+auth-service-url-allow-insecure=true
+
+## This user can run list_running_apps method to get states
+## of all running apps (running internally on wrapper side).
+admin.user=
+
+# Following parameters define Catalog admin creds for pushing exec-stats:
+catalog.admin.token=
+
+default.awe.client.groups=ci
+awe.readonly.admin.token=
+awe.client.callback.networks=docker0,eth0
+running.tasks.per.user=5
+
+mongodb-host = ci-mongo:27017
+mongodb-database = exec_engine
+mongodb-user = mini_kb
+mongodb-pwd = mini_kb_password
+
+ujs-mongodb-host = ci-mongo:27017
+ujs-mongodb-database = userjobstate
+ujs-mongodb-user = mini_kb
+ujs-mongodb-pwd = mini_kb_password
+
+narrative.proxy.sharing.user=narrativejoblistener
+
+# This next flag really doesn't make sense to me as a startup option, but copying from CI config
+## Please change next flag before you reboot machine.
+## It will help keep tasks in queue and rerun them later.
+## Don't forget to revert this flag after reboot.
+reboot.mode=false
+
+condor.mode=1
+condor.submit.desc.file.path=../scripts/

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -32,8 +32,6 @@ public class CondorUtils {
         String clientGroups = reqs.get("client_group");
 
         HashMap<String,String> envVariables = new HashMap<>();
-
-
         String request_cpus = "request_cpus = 1";
         String request_memory = "request_memory = 5MB";
         String request_disk = "request_disk = 1MB";

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -28,15 +28,41 @@ public class CondorUtils {
      * @throws IOException
      */
     private static File createCondorSubmitFile(String ujsJobId, AuthToken token, AuthToken adminToken, String clientGroupsAndRequirements, String kbaseEndpoint, String baseDir, HashMap<String, String> optClassAds) throws IOException {
-
         HashMap<String, String> reqs = clientGroupsAndRequirements(clientGroupsAndRequirements);
         String clientGroups = reqs.get("client_group");
-        String request_cpus = String.format("%s = %s",
-                "request_cpus", reqs.getOrDefault("request_cpus", "1"));
-        String request_memory = String.format("%s = %s",
-                "request_memory", reqs.getOrDefault("request_memory", "5MB"));
-        String request_disk = String.format("%s = %s",
-                "request_disk", reqs.getOrDefault("request_disk", "1MB"));
+
+        HashMap<String,String> envVariables = new HashMap<>();
+
+
+        String request_cpus = "request_cpus = 1";
+        String request_memory = "request_memory = 5MB";
+        String request_disk = "request_disk = 1MB";
+
+        //Default at MB for now
+        String request_cpus_key = "request_cpus";
+        if (reqs.containsKey(request_cpus_key)) {
+            request_cpus = String.format("%s = %s", request_cpus_key, reqs.get(request_cpus_key));
+            envVariables.put(request_cpus_key, reqs.get(request_cpus_key));
+        }
+        String request_memory_key = "request_memory";
+        if (reqs.containsKey(request_memory_key)) {
+            request_memory = String.format("%s = %sMB", request_memory_key, reqs.get(request_memory_key));
+            envVariables.put(request_memory_key, reqs.get(request_memory_key));
+        }
+        String request_disk_key = "request_disk";
+        if (reqs.containsKey(request_disk_key)) {
+            request_disk = String.format("%s = %sMB", request_disk_key, reqs.get(request_disk_key));
+        }
+
+        envVariables.put("KB_AUTH_TOKEN",token.getToken());
+        envVariables.put("KB_ADMIN_AUTH_TOKEN",adminToken.getToken());
+        envVariables.put("AWE_CLIENTGROUP",clientGroups);
+        envVariables.put("BASE_DIR",baseDir);
+
+        List<String> environment = new ArrayList<String>();
+        for(String key : envVariables.keySet() ){
+            environment.add(String.format("%s=%s",key, envVariables.get(key)));
+        }
 
         String executable = "/kb/deployment/misc/sdklocalmethodrunner.sh";
         String[] args = {ujsJobId, kbaseEndpoint};
@@ -49,15 +75,18 @@ public class CondorUtils {
         csf.add("executable = " + executable);
         csf.add("ShouldTransferFiles = YES");
         csf.add("when_to_transfer_output = ON_EXIT");
+        csf.add("transfer_input_files = /kb/deployment/lib/NJSWrapper-all.jar");
         csf.add(request_cpus);
         csf.add(request_memory);
         csf.add(request_disk);
         csf.add("log    = logfile.txt");
         csf.add("output = outfile.txt");
         csf.add("error  = errors.txt");
-        csf.add("getenv = true");
+        csf.add("getenv = false");
         csf.add("requirements = " + reqs.get("requirements_statement"));
-        csf.add(String.format("environment = \"KB_AUTH_TOKEN=%s KB_ADMIN_AUTH_TOKEN=%s AWE_CLIENTGROUP=%s BASE_DIR=%s\"", token.getToken(), adminToken.getToken(), clientGroups, baseDir));
+        csf.add(String.format("environment = \"%s\"",String.join(" ", environment)));
+
+        //csf.add(String.format("environment = \"KB_AUTH_TOKEN=%s KB_ADMIN_AUTH_TOKEN=%s AWE_CLIENTGROUP=%s BASE_DIR=%s\"", token.getToken(), adminToken.getToken(), clientGroups, baseDir));
         csf.add("arguments = " + arguments);
         csf.add("batch_name = " + ujsJobId);
         if (optClassAds != null) {
@@ -126,6 +155,9 @@ public class CondorUtils {
      * @return a map of client_groups, resource_requirements, and classAds
      */
     public static HashMap<String, String> clientGroupsAndRequirements(String clientGroupsAndRequirements) {
+
+        //Here is a working example of what might come in the clientGroupsAndRequirements
+        clientGroupsAndRequirements = "njs,request_memory=10,request_cpus=1,request_disk=10";
 
         String[] items = clientGroupsAndRequirements.split(",");
         String clientGroup = cleanCondorInputs(items[0]);
@@ -206,7 +238,7 @@ public class CondorUtils {
             throw new IOException("Error running condorCommand:" + String.join(" ", cmdScript));
         }
         if(! optClassAds.containsKey("debugMode")) {
-            condorSubmitFile.delete();
+            //condorSubmitFile.delete();
         }
         return jobID;
     }

--- a/src/us/kbase/common/utils/CondorUtils.java
+++ b/src/us/kbase/common/utils/CondorUtils.java
@@ -157,7 +157,7 @@ public class CondorUtils {
     public static HashMap<String, String> clientGroupsAndRequirements(String clientGroupsAndRequirements) {
 
         //Here is a working example of what might come in the clientGroupsAndRequirements
-        clientGroupsAndRequirements = "njs,request_memory=10,request_cpus=1,request_disk=10";
+        //clientGroupsAndRequirements = "njs,request_memory=500,request_cpus=1,request_disk=10";
 
         String[] items = clientGroupsAndRequirements.split(",");
         String clientGroup = cleanCondorInputs(items[0]);

--- a/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/DockerRunner.java
@@ -303,8 +303,8 @@ public class DockerRunner {
             System.out.println("Attempting to kill job due to cancellation or sig-kill:" + subjobid);
             try {
                 cl.killContainerCmd(subjobid);
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception ignore) {
+                //e.printStackTrace();
             }
         }
     }
@@ -371,6 +371,13 @@ public class DockerRunner {
         }
     }
 
+    /**
+     * Impose cpu and memory limits into a hostconfig
+     *
+     * @param resourceRequirements request_cpus and request_memory to be translated into a cpu limit and a soft memory limit
+     * @param log logger
+     * @return a hostconfig with constrainted memory and or cpu
+     */
     public HostConfig setJobRequirements(Map<String, String> resourceRequirements, LineLogger log) {
         if (resourceRequirements == null || resourceRequirements.isEmpty()) {
             return null;

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
@@ -112,9 +112,7 @@ public class SDKLocalMethodRunner {
             }
         };
 
-
         Runtime.getRuntime().addShutdownHook(shutdownHook);
-
 
         String[] hostnameAndIP = getHostnameAndIP();
         final String jobId = args[0];

--- a/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
+++ b/src/us/kbase/narrativejobservice/sdkjobs/SDKLocalMethodRunner.java
@@ -16,7 +16,9 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.mongodb.util.Hash;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -87,7 +89,7 @@ public class SDKLocalMethodRunner {
             JobRunnerConstants.CFG_PROP_AWE_CLIENT_CALLBACK_NETWORKS;
 
     public static void main(String[] args) throws Exception {
-        System.out.println("Starting docker runner with args " +
+        System.out.println("Starting docker runner EDIT EDIT EDIT with args " +
             StringUtils.join(args, ", "));
         if (args.length != 2) {
             System.err.println("Usage: <program> <job_id> <job_service_url>");
@@ -441,10 +443,34 @@ public class SDKLocalMethodRunner {
             labels.put("user_name",token.getUserName());
 
 
+
+            Map<String,String> resourceRequirements = new HashMap<String,String>();
+
+
+
+            String[] resourceStrings = {"request_cpus","request_memory","request_disk"};
+
+            for(String resourceKey : resourceStrings) {
+                String resourceValue  = System.getenv(resourceKey);
+                if(resourceValue != null && !resourceKey.isEmpty()) {
+                    resourceRequirements.put(resourceKey,resourceValue);
+                }
+            }
+            if(resourceRequirements.isEmpty()) {
+                resourceRequirements = null;
+                log.logNextLine("Resource Requirements are not specified.", true);
+            }
+            else{
+                log.logNextLine("Resource Requirements are:", true);
+                log.logNextLine(resourceRequirements.toString(), true);
+            }
+
+
+
             // Calling Docker run
             new DockerRunner(dockerURI).run(imageName, modMeth.getModule(), inputFile, token, log,
                     outputFile, false, refDataDir, null, callbackUrl, jobId, additionalBinds,
-                    cancellationChecker, envVars, labels);
+                    cancellationChecker, envVars, labels,resourceRequirements);
             if (cancellationChecker.isJobCanceled()) {
                 log.logNextLine("Job was canceled", false);
                 flushLog(jobSrvClient, jobId, logLines);

--- a/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
+++ b/src/us/kbase/narrativejobservice/subjobs/NJSSubsequentCallRunner.java
@@ -77,7 +77,7 @@ public class NJSSubsequentCallRunner extends SubsequentCallRunner {
                 imageName, moduleName, inputFile.toFile(), token,
                 config.getLogger(), outputFile.toFile(), false, refDataDir,
                 sharedScratchDir.toFile(), config.getCallbackURL(),
-                jobId.toString(), additionalBinds, cancellationChecker, null, labels);
+                jobId.toString(), additionalBinds, cancellationChecker, null, labels, null);
         return outputFile;
     }
     


### PR DESCRIPTION
What I'm doing for resources: basically we can pass in CPU and memory to condor. Then I take that passed in value and send it to the main docker job. CPU limits can be set, as well as memory limits. Memory limits can be a hard limit or a soft limit. Subjobs currently do not get any limits applied to them in the current version of the code