### PR TITLE
SCT-1789 Update mongo client to 3.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     implementation 'apache_commons:commons-logging:1.1.1'
     implementation 'apache_commons:commons-lang:2.4'
     implementation 'apache_commons:commons-lang3:3.1'
-    implementation 'mongo:mongo-java-driver:2.13.3'
+    implementation 'mongo:mongo-java-driver:3.10.1'
     implementation 'bson4jackson:bson4jackson:2.2.0-2.2.0'
     implementation 'com.aries:docker-java-shaded:3.0.14'
 }


### PR DESCRIPTION
Note the new mongo client spams the logs, may want to crank that down a little

```
~/localgit/njs_wrapper$ grep mongo test.cfg
# the path to the MongoDB executable. Omit to use mongod found on the path.
#test-mongod-exe=
#test-mongod-exe=/home/crusherofheads/mongo/2.6.11/bin/mongod
test-mongod-exe=/home/crusherofheads/mongo/3.6.10/bin/mongod

~/localgit/njs_wrapper$ ./gradlew test --tests ExecEngineMongoDbTest

> Configure project :
Deleting dist and deployment/lib
Copying all files from dist to deployment/lib
Copying from dist/NJSWrapper-unspecified.jar to deployment/lib/NJSWrapper.jar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 0s
3 actionable tasks: 3 up-to-date
```